### PR TITLE
feat(config): add configuration validation to TTS config classes

### DIFF
--- a/src/champi_tts/core/base_config.py
+++ b/src/champi_tts/core/base_config.py
@@ -7,6 +7,10 @@ from dataclasses import dataclass
 from typing import Any
 
 
+_VALID_AUDIO_FORMATS = frozenset({"wav", "mp3", "flac", "pcm", "ogg"})
+_MIN_CHUNK_SIZE = 50
+
+
 @dataclass
 class BaseTTSConfig(ABC):
     """Abstract base class for TTS provider configuration."""
@@ -34,10 +38,34 @@ class BaseTTSConfig(ABC):
         """Create configuration from environment variables."""
         pass
 
-    @abstractmethod
     def validate(self) -> bool:
-        """Validate configuration settings."""
-        pass
+        """Validate common configuration settings.
+
+        Raises:
+            ValueError: If any configuration value is invalid.
+
+        Returns:
+            True if all settings are valid.
+        """
+        if self.sample_rate <= 0:
+            raise ValueError(
+                f"sample_rate must be a positive integer, got {self.sample_rate}"
+            )
+        if self.default_speed <= 0:
+            raise ValueError(
+                f"default_speed must be positive, got {self.default_speed}"
+            )
+        if self.streaming_chunk_size < _MIN_CHUNK_SIZE:
+            raise ValueError(
+                f"streaming_chunk_size must be >= {_MIN_CHUNK_SIZE}, "
+                f"got {self.streaming_chunk_size}"
+            )
+        if self.audio_format not in _VALID_AUDIO_FORMATS:
+            raise ValueError(
+                f"audio_format must be one of {sorted(_VALID_AUDIO_FORMATS)}, "
+                f"got '{self.audio_format}'"
+            )
+        return True
 
     def to_dict(self) -> dict[str, Any]:
         """Convert configuration to dictionary."""

--- a/src/champi_tts/providers/kokoro/config.py
+++ b/src/champi_tts/providers/kokoro/config.py
@@ -9,6 +9,42 @@ from typing import Any
 
 from loguru import logger
 
+from champi_tts.providers.kokoro.enums import VoiceLanguage
+
+# Valid two-letter prefixes that identify gender/language of a voice.
+# Format: language-code + gender initial (f=female, m=male).
+VALID_VOICE_PREFIXES: frozenset[str] = frozenset(
+    {
+        "af",
+        "am",
+        "bf",
+        "bm",
+        "ef",
+        "em",
+        "ff",
+        "fm",
+        "hf",
+        "hm",
+        "if",
+        "im",
+        "jf",
+        "jm",
+        "pf",
+        "pm",
+        "zf",
+        "zm",
+    }
+)
+
+# Accepted language codes: all VoiceLanguage enum values plus plain "en".
+VALID_LANGUAGE_CODES: frozenset[str] = frozenset(
+    lang.value for lang in VoiceLanguage
+) | {"en"}
+
+# Speed limits enforced by validate().
+SPEED_MIN: float = 0.5
+SPEED_MAX: float = 2.0
+
 
 @dataclass
 class KokoroConfig:
@@ -57,25 +93,57 @@ class KokoroConfig:
     max_text_length: int = 100000
     retry_on_failure: bool = True
 
-    def __post_init__(self):
-        """Post-initialization validation"""
-        # Validate language code
-        valid_languages = ["a", "b", "en", "en-us", "en-gb"]
-        if self.default_language not in valid_languages:
-            logger.warning(f"Invalid language code: {self.default_language}, using 'a'")
-            self.default_language = "a"
+    def __post_init__(self) -> None:
+        """Validate configuration on construction."""
+        self.validate()
 
-        # Validate speed
-        if not (0.1 <= self.default_speed <= 3.0):
-            logger.warning(f"Invalid speed: {self.default_speed}, using 1.0")
-            self.default_speed = 1.0
+    def validate(self) -> bool:
+        """Validate Kokoro configuration settings.
 
-        # Validate chunk size
-        if self.streaming_chunk_size < 50:
-            logger.warning(
-                f"Chunk size too small: {self.streaming_chunk_size}, using 200"
+        Raises:
+            ValueError: If any configuration value is invalid.
+
+        Returns:
+            True if all settings are valid.
+        """
+        if not (SPEED_MIN <= self.default_speed <= SPEED_MAX):
+            raise ValueError(
+                f"default_speed must be between {SPEED_MIN} and {SPEED_MAX}, "
+                f"got {self.default_speed}"
             )
-            self.streaming_chunk_size = 200
+
+        if self.default_voice:
+            parts = self.default_voice.split("_", 1)
+            if len(parts) < 2 or parts[0] not in VALID_VOICE_PREFIXES:
+                raise ValueError(
+                    f"Invalid voice name '{self.default_voice}'. "
+                    f"Voice names must follow the pattern '<prefix>_<name>' "
+                    f"where prefix is one of: {', '.join(sorted(VALID_VOICE_PREFIXES))}"
+                )
+
+        if self.default_language not in VALID_LANGUAGE_CODES:
+            raise ValueError(
+                f"Invalid language code '{self.default_language}'. "
+                f"Valid codes: {', '.join(sorted(VALID_LANGUAGE_CODES))}"
+            )
+
+        if self.streaming_chunk_size < 50:
+            raise ValueError(
+                f"streaming_chunk_size must be >= 50, got {self.streaming_chunk_size}"
+            )
+
+        if self.max_text_length <= 0:
+            raise ValueError(
+                f"max_text_length must be positive, got {self.max_text_length}"
+            )
+
+        supported = self.supported_audio_formats
+        if self.audio_format not in supported:
+            raise ValueError(
+                f"audio_format must be one of {supported}, got '{self.audio_format}'"
+            )
+
+        return True
 
     @classmethod
     def from_dict(cls, config_dict: dict[str, Any]) -> "KokoroConfig":
@@ -184,6 +252,7 @@ class KokoroConfig:
         if env_value := os.environ.get("CHAMPI_AUTO_START_KOKORO"):
             config.auto_start = env_value.lower() in ["true", "1", "yes"]
 
+        config.validate()
         return config
 
     @property

--- a/tests/test_core/test_config_validation.py
+++ b/tests/test_core/test_config_validation.py
@@ -1,0 +1,246 @@
+"""
+Tests for configuration validation in BaseTTSConfig and KokoroConfig.
+"""
+
+import pytest
+
+from champi_tts.core.base_config import BaseTTSConfig
+from champi_tts.providers.kokoro.config import (
+    SPEED_MAX,
+    SPEED_MIN,
+    VALID_LANGUAGE_CODES,
+    VALID_VOICE_PREFIXES,
+    KokoroConfig,
+)
+
+
+# ---------------------------------------------------------------------------
+# Minimal concrete subclass used to exercise BaseTTSConfig.validate() directly.
+# ---------------------------------------------------------------------------
+
+
+class _ConcreteConfig(BaseTTSConfig):
+    """Concrete subclass that delegates validate() to the base implementation."""
+
+    @classmethod
+    def from_env(cls) -> "_ConcreteConfig":
+        return cls()
+
+    def validate(self) -> bool:
+        return super().validate()
+
+
+# ---------------------------------------------------------------------------
+# BaseTTSConfig.validate() tests
+# ---------------------------------------------------------------------------
+
+
+class TestBaseTTSConfigValidate:
+    """Tests for BaseTTSConfig.validate()."""
+
+    def test_valid_defaults_return_true(self):
+        """Default values pass validation without error."""
+        cfg = _ConcreteConfig()
+        assert cfg.validate() is True
+
+    def test_raises_for_zero_sample_rate(self):
+        """sample_rate of 0 is rejected."""
+        cfg = _ConcreteConfig()
+        cfg.sample_rate = 0
+        with pytest.raises(ValueError, match="sample_rate"):
+            cfg.validate()
+
+    def test_raises_for_negative_sample_rate(self):
+        """Negative sample_rate is rejected."""
+        cfg = _ConcreteConfig()
+        cfg.sample_rate = -8000
+        with pytest.raises(ValueError, match="sample_rate"):
+            cfg.validate()
+
+    def test_raises_for_zero_default_speed(self):
+        """default_speed of 0 is rejected."""
+        cfg = _ConcreteConfig()
+        cfg.default_speed = 0.0
+        with pytest.raises(ValueError, match="default_speed"):
+            cfg.validate()
+
+    def test_raises_for_negative_default_speed(self):
+        """Negative default_speed is rejected."""
+        cfg = _ConcreteConfig()
+        cfg.default_speed = -1.0
+        with pytest.raises(ValueError, match="default_speed"):
+            cfg.validate()
+
+    def test_raises_for_chunk_size_below_minimum(self):
+        """streaming_chunk_size below 50 is rejected."""
+        cfg = _ConcreteConfig()
+        cfg.streaming_chunk_size = 49
+        with pytest.raises(ValueError, match="streaming_chunk_size"):
+            cfg.validate()
+
+    def test_accepts_chunk_size_at_minimum(self):
+        """streaming_chunk_size of exactly 50 is accepted."""
+        cfg = _ConcreteConfig()
+        cfg.streaming_chunk_size = 50
+        assert cfg.validate() is True
+
+    def test_raises_for_unknown_audio_format(self):
+        """Unrecognised audio_format is rejected."""
+        cfg = _ConcreteConfig()
+        cfg.audio_format = "aiff"
+        with pytest.raises(ValueError, match="audio_format"):
+            cfg.validate()
+
+    @pytest.mark.parametrize("fmt", ["wav", "mp3", "flac", "pcm", "ogg"])
+    def test_accepts_all_valid_audio_formats(self, fmt):
+        """Every supported audio format passes validation."""
+        cfg = _ConcreteConfig()
+        cfg.audio_format = fmt
+        assert cfg.validate() is True
+
+
+# ---------------------------------------------------------------------------
+# KokoroConfig.validate() tests
+# ---------------------------------------------------------------------------
+
+
+class TestKokoroConfigValidate:
+    """Tests for KokoroConfig.validate()."""
+
+    def test_valid_defaults_return_true(self):
+        """Default KokoroConfig passes validation."""
+        cfg = KokoroConfig()
+        assert cfg.validate() is True
+
+    # -- speed -----------------------------------------------------------
+
+    def test_raises_for_speed_below_minimum(self):
+        """Speed below SPEED_MIN raises ValueError."""
+        with pytest.raises(ValueError, match="default_speed"):
+            KokoroConfig(default_speed=SPEED_MIN - 0.1)
+
+    def test_raises_for_speed_above_maximum(self):
+        """Speed above SPEED_MAX raises ValueError."""
+        with pytest.raises(ValueError, match="default_speed"):
+            KokoroConfig(default_speed=SPEED_MAX + 0.1)
+
+    def test_accepts_speed_at_minimum_boundary(self):
+        """Speed exactly at SPEED_MIN is accepted."""
+        cfg = KokoroConfig(default_speed=SPEED_MIN)
+        assert cfg.default_speed == SPEED_MIN
+
+    def test_accepts_speed_at_maximum_boundary(self):
+        """Speed exactly at SPEED_MAX is accepted."""
+        cfg = KokoroConfig(default_speed=SPEED_MAX)
+        assert cfg.default_speed == SPEED_MAX
+
+    def test_accepts_speed_within_range(self):
+        """Speed clearly within range is accepted."""
+        cfg = KokoroConfig(default_speed=1.2)
+        assert cfg.default_speed == 1.2
+
+    # -- voice -----------------------------------------------------------
+
+    def test_raises_for_voice_with_invalid_prefix(self):
+        """Voice name with unknown prefix raises ValueError."""
+        with pytest.raises(ValueError, match="voice"):
+            KokoroConfig(default_voice="xx_unknown")
+
+    def test_raises_for_voice_without_underscore(self):
+        """Voice name without underscore separator raises ValueError."""
+        with pytest.raises(ValueError, match="voice"):
+            KokoroConfig(default_voice="afbella")
+
+    def test_error_message_lists_valid_prefixes(self):
+        """Error message for invalid voice name includes the valid prefixes."""
+        with pytest.raises(ValueError, match="af"):
+            KokoroConfig(default_voice="bad_name")
+
+    def test_accepts_empty_voice_name(self):
+        """Empty string for default_voice is accepted (auto-select)."""
+        cfg = KokoroConfig(default_voice="")
+        assert cfg.default_voice == ""
+
+    @pytest.mark.parametrize("prefix", sorted(VALID_VOICE_PREFIXES))
+    def test_accepts_all_valid_voice_prefixes(self, prefix):
+        """Every valid voice prefix is accepted."""
+        cfg = KokoroConfig(default_voice=f"{prefix}_testvoice")
+        assert cfg.default_voice.startswith(prefix)
+
+    # -- language --------------------------------------------------------
+
+    def test_raises_for_invalid_language_code(self):
+        """Unknown language code raises ValueError."""
+        with pytest.raises(ValueError, match="language"):
+            KokoroConfig(default_language="xyz")
+
+    @pytest.mark.parametrize("code", sorted(VALID_LANGUAGE_CODES))
+    def test_accepts_all_valid_language_codes(self, code):
+        """Every valid language code is accepted."""
+        cfg = KokoroConfig(default_language=code)
+        assert cfg.default_language == code
+
+    # -- streaming_chunk_size --------------------------------------------
+
+    def test_raises_for_chunk_size_below_minimum(self):
+        """streaming_chunk_size below 50 raises ValueError."""
+        with pytest.raises(ValueError, match="streaming_chunk_size"):
+            KokoroConfig(streaming_chunk_size=10)
+
+    def test_accepts_chunk_size_at_minimum(self):
+        """streaming_chunk_size of exactly 50 is accepted."""
+        cfg = KokoroConfig(streaming_chunk_size=50)
+        assert cfg.streaming_chunk_size == 50
+
+    # -- max_text_length -------------------------------------------------
+
+    def test_raises_for_zero_max_text_length(self):
+        """max_text_length of 0 raises ValueError."""
+        with pytest.raises(ValueError, match="max_text_length"):
+            KokoroConfig(max_text_length=0)
+
+    def test_raises_for_negative_max_text_length(self):
+        """Negative max_text_length raises ValueError."""
+        with pytest.raises(ValueError, match="max_text_length"):
+            KokoroConfig(max_text_length=-1)
+
+    # -- audio_format ----------------------------------------------------
+
+    def test_raises_for_unsupported_audio_format(self):
+        """Unsupported audio_format raises ValueError."""
+        with pytest.raises(ValueError, match="audio_format"):
+            KokoroConfig(audio_format="aiff")
+
+    @pytest.mark.parametrize("fmt", ["mp3", "opus", "flac", "wav", "pcm"])
+    def test_accepts_all_supported_audio_formats(self, fmt):
+        """Every Kokoro-supported audio format is accepted."""
+        cfg = KokoroConfig(audio_format=fmt)
+        assert cfg.audio_format == fmt
+
+    # -- construction integration ----------------------------------------
+
+    def test_construction_raises_with_invalid_speed(self):
+        """Construction fails immediately when speed is out of range."""
+        with pytest.raises(ValueError, match="default_speed"):
+            KokoroConfig(default_speed=5.0)
+
+    def test_construction_raises_with_invalid_voice(self):
+        """Construction fails immediately when voice name is malformed."""
+        with pytest.raises(ValueError, match="voice"):
+            KokoroConfig(default_voice="invalid")
+
+    def test_construction_raises_with_invalid_language(self):
+        """Construction fails immediately when language code is unknown."""
+        with pytest.raises(ValueError, match="language"):
+            KokoroConfig(default_language="zz")
+
+    def test_validate_called_at_construction(self):
+        """validate() is invoked by __post_init__ so invalid args raise on init."""
+        with pytest.raises(ValueError):
+            KokoroConfig(default_speed=0.1)
+
+    def test_explicit_validate_call_returns_true(self):
+        """Calling validate() on a valid config returns True."""
+        cfg = KokoroConfig()
+        result = cfg.validate()
+        assert result is True


### PR DESCRIPTION
## Summary
- Add concrete `validate()` method to `BaseTTSConfig` (was abstract/unimplemented)
- Add `validate()` to `KokoroConfig` with checks for voice prefix, language code, and speed range
- Add constants `VALID_VOICE_PREFIXES`, `VALID_LANGUAGE_CODES`, `SPEED_MIN`, `SPEED_MAX` to `KokoroConfig`
- Add 30+ test cases in `tests/test_core/test_config_validation.py`

## Test plan
- [ ] `uv run pytest tests/test_core/test_config_validation.py -v` passes all tests
- [ ] Invalid voice/language/speed raises `ValueError` with descriptive message
- [ ] Valid configs pass without exception

Closes #6