### PR TITLE
perf: implement lazy loading for heavy optional dependencies

### DIFF
--- a/src/champi_tts/__init__.py
+++ b/src/champi_tts/__init__.py
@@ -65,21 +65,50 @@ from champi_tts.factory import (
     list_providers,
 )
 
-# Backwards compatibility: expose Kokoro directly
-from champi_tts.providers.kokoro import (
-    KokoroConfig,
-    KokoroInference,
-    KokoroProvider,
-    VoiceManager,
-)
-
 # Reader service
 from champi_tts.reader import ReaderState, TextReaderService
 
-# UI components
-from champi_tts.ui import TTSIndicatorUI, TTSState
-
 __version__ = "1.1.1"
+
+# Names from optional extras that are loaded lazily to avoid pulling in
+# heavy dependencies (torch, kokoro, imgui-bundle) at import time.
+_KOKORO_EXPORTS = frozenset(
+    {"KokoroConfig", "KokoroInference", "KokoroProvider", "VoiceManager"}
+)
+_UI_EXPORTS = frozenset({"TTSIndicatorUI", "TTSState"})
+
+
+def __getattr__(name: str) -> object:
+    """Lazily import optional-extra symbols to keep startup fast."""
+    if name in _KOKORO_EXPORTS:
+        from champi_tts.providers.kokoro import (
+            KokoroConfig,
+            KokoroInference,
+            KokoroProvider,
+            VoiceManager,
+        )
+
+        _resolved = {
+            "KokoroConfig": KokoroConfig,
+            "KokoroInference": KokoroInference,
+            "KokoroProvider": KokoroProvider,
+            "VoiceManager": VoiceManager,
+        }
+        globals().update(_resolved)
+        return _resolved[name]
+
+    if name in _UI_EXPORTS:
+        from champi_tts.ui import TTSIndicatorUI, TTSState
+
+        _resolved = {
+            "TTSIndicatorUI": TTSIndicatorUI,
+            "TTSState": TTSState,
+        }
+        globals().update(_resolved)
+        return _resolved[name]
+
+    raise AttributeError(f"module 'champi_tts' has no attribute {name!r}")
+
 
 __all__ = [
     "BaseSynthesizer",

--- a/src/champi_tts/providers/kokoro/inference.py
+++ b/src/champi_tts/providers/kokoro/inference.py
@@ -3,23 +3,22 @@ Core Kokoro TTS inference engine.
 Extracted from Kokoro-FastAPI for direct integration.
 """
 
+from __future__ import annotations
+
 import asyncio
+import contextlib
 import os
 import tempfile
 import time
 from collections.abc import AsyncGenerator
+from typing import TYPE_CHECKING
 
 import numpy as np
-import torch
 from loguru import logger
 
-try:
+if TYPE_CHECKING:
+    import torch
     from kokoro import KModel, KPipeline
-except ImportError:
-    logger.error("Kokoro package not found. Install with: pip install kokoro-tts")
-    raise
-
-import contextlib
 
 from champi_tts.providers.kokoro.config import KokoroConfig
 from champi_tts.providers.kokoro.enums import (
@@ -43,7 +42,7 @@ class AudioChunk:
         self.output = output
 
     @staticmethod
-    def combine(chunks: list["AudioChunk"]) -> "AudioChunk":
+    def combine(chunks: list[AudioChunk]) -> AudioChunk:
         """Combine multiple audio chunks"""
         if not chunks:
             return AudioChunk(np.array([], dtype=np.int16))
@@ -80,6 +79,8 @@ class KokoroInference:
 
     def _determine_device(self) -> str:
         """Determine best available device"""
+        import torch
+
         if self.config.force_cpu:
             return "cpu"
         elif torch.cuda.is_available() and self.config.use_gpu:
@@ -92,6 +93,16 @@ class KokoroInference:
     @EventProcessor.emits_event(data=["device", "model"])
     async def load_model(self, model_path: str, config_path: str) -> None:
         """Load Kokoro model from files"""
+        import torch
+
+        try:
+            from kokoro import KModel
+        except ImportError:
+            logger.error(
+                "Kokoro package not found. Install with: pip install kokoro-tts"
+            )
+            raise
+
         try:
             if not os.path.exists(model_path):
                 raise FileNotFoundError(f"Model file not found: {model_path}")
@@ -125,6 +136,8 @@ class KokoroInference:
 
     def _get_pipeline(self, lang_code: str) -> KPipeline:
         """Get or create pipeline for language"""
+        from kokoro import KPipeline
+
         if not self._initialized:
             raise RuntimeError("Model not loaded. Call load_model() first.")
 
@@ -138,6 +151,8 @@ class KokoroInference:
 
     def _load_voice_tensor(self, voice_path: str) -> torch.Tensor:
         """Load and prepare voice tensor"""
+        import torch
+
         if not os.path.exists(voice_path):
             raise FileNotFoundError(f"Voice file not found: {voice_path}")
 
@@ -162,6 +177,8 @@ class KokoroInference:
         self, voice_tensor: torch.Tensor, voice_name: str
     ) -> str:
         """Save voice tensor to temporary file"""
+        import torch
+
         temp_dir = tempfile.gettempdir()
         temp_path = os.path.join(temp_dir, f"kokoro_voice_{voice_name}.pt")
 
@@ -394,6 +411,8 @@ class KokoroInference:
 
     def unload(self) -> None:
         """Unload model and free resources"""
+        import torch
+
         if self.model is not None:
             del self.model
             self.model = None

--- a/src/champi_tts/ui/tts_indicator_ui.py
+++ b/src/champi_tts/ui/tts_indicator_ui.py
@@ -6,7 +6,6 @@ import sys
 import time
 from enum import Enum
 
-from imgui_bundle import imgui, immapp
 from loguru import logger
 
 
@@ -56,6 +55,8 @@ class TTSIndicatorUI:
 
     def gui(self) -> None:
         """Render the ImGui interface."""
+        from imgui_bundle import imgui
+
         # Set window position
         imgui.set_next_window_pos(
             imgui.ImVec2(self.window_x, self.window_y),
@@ -134,6 +135,8 @@ class TTSIndicatorUI:
 
     def run(self) -> None:
         """Run the UI main loop."""
+        from imgui_bundle import immapp
+
         immapp.run(
             gui_function=self.gui,
             window_title="Champi TTS",
@@ -144,6 +147,8 @@ class TTSIndicatorUI:
 
 def run_standalone(window_x: int = 50, window_y: int = 50) -> None:
     """Run the indicator UI in standalone mode for testing."""
+    from imgui_bundle import imgui, immapp
+
     ui = TTSIndicatorUI(window_x=window_x, window_y=window_y)
 
     # Test state cycling


### PR DESCRIPTION
## Summary
- Move `torch`/`kokoro` imports to function level in `inference.py` with `TYPE_CHECKING` guard
- Move `imgui_bundle` imports inside methods in `tts_indicator_ui.py`
- Add `__getattr__` to `__init__.py` for deferred module-level attribute access
- Reduces cold-start import time when optional deps (torch, kokoro, imgui) are not installed

## Test plan
- [ ] `python -c "import champi_tts"` does not import torch/kokoro
- [ ] `uv run pytest tests/ -v --no-cov` still passes
- [ ] Lazy import benchmark shows reduced import time

Closes #5