### PR TITLE
perf: add performance benchmark suite

### DIFF
--- a/benchmarks/bench_imports.py
+++ b/benchmarks/bench_imports.py
@@ -1,0 +1,80 @@
+"""
+Import-time and lazy-loading benchmarks.
+
+Verifies that importing champi_tts at the top level is lightweight and
+that heavy provider dependencies (torch, kokoro) are deferred until
+first use. Module-cache manipulation forces the import machinery to
+re-execute on every iteration so timing is meaningful.
+
+Run with:
+    uv run pytest benchmarks/ --benchmark-only -v
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _pop_champi_modules() -> dict[str, object]:
+    """Remove all champi_tts entries from sys.modules and return them."""
+    to_remove = [k for k in sys.modules if k.startswith("champi_tts")]
+    return {k: sys.modules.pop(k) for k in to_remove}
+
+
+# ---------------------------------------------------------------------------
+# Import-time benchmarks
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.benchmark(group="imports")
+def test_bench_reimport_champi_tts(benchmark) -> None:
+    """Measure champi_tts re-import time after clearing the module cache."""
+
+    def _reimport() -> str:
+        saved = _pop_champi_modules()
+        try:
+            mod = importlib.import_module("champi_tts")
+            return mod.__version__
+        finally:
+            sys.modules.update(saved)
+
+    version = benchmark(_reimport)
+    assert version is not None
+
+
+@pytest.mark.benchmark(group="imports")
+def test_bench_lazy_heavy_deps_absent(benchmark) -> None:
+    """torch and kokoro must not appear in sys.modules after a bare import."""
+
+    def _check() -> tuple[bool, bool]:
+        return "torch" not in sys.modules, "kokoro" not in sys.modules
+
+    no_torch, no_kokoro = benchmark(_check)
+    assert no_torch, "torch was eagerly imported at the top level"
+    assert no_kokoro, "kokoro was eagerly imported at the top level"
+
+
+@pytest.mark.benchmark(group="imports")
+def test_bench_list_providers(benchmark) -> None:
+    """list_providers() is O(1) — a constant lookup with no I/O."""
+    from champi_tts import list_providers
+
+    result = benchmark(list_providers)
+    assert "kokoro" in result
+
+
+@pytest.mark.benchmark(group="imports")
+def test_bench_kokoro_config_creation(benchmark) -> None:
+    """KokoroConfig construction does not trigger model or torch loading."""
+    from champi_tts.providers.kokoro import KokoroConfig
+
+    result = benchmark(KokoroConfig)
+    assert result.sample_rate == 24000

--- a/benchmarks/bench_reader.py
+++ b/benchmarks/bench_reader.py
@@ -1,0 +1,131 @@
+"""
+Text reader queue and state benchmarks.
+
+Measures the throughput of queue operations and state-machine transitions
+in TextReaderService. All benchmarks are synchronous — no audio playback
+or event-loop scheduling is involved, so no hardware is required.
+
+Run with:
+    uv run pytest benchmarks/ --benchmark-only -v
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from champi_tts.reader import ReaderState, TextReaderService
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_reader(mocked_reader_provider: Any) -> TextReaderService:
+    """Create a TextReaderService backed by a minimal mock provider."""
+    return TextReaderService(provider=mocked_reader_provider, show_ui=False)
+
+
+# ---------------------------------------------------------------------------
+# Queue benchmarks
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.benchmark(group="queue")
+def test_bench_add_to_queue_single(
+    benchmark, mocked_reader_provider: Any
+) -> None:
+    """Latency of a single add_to_queue call followed by clear_queue."""
+    reader = _make_reader(mocked_reader_provider)
+
+    def _add_and_clear() -> None:
+        reader.add_to_queue("Hello world.")
+        reader.clear_queue()
+
+    benchmark(_add_and_clear)
+    assert reader._text_queue == []
+
+
+@pytest.mark.benchmark(group="queue")
+def test_bench_add_to_queue_batch(
+    benchmark, mocked_reader_provider: Any
+) -> None:
+    """Throughput of adding 100 items to the queue then clearing."""
+    reader = _make_reader(mocked_reader_provider)
+    texts = [f"Sentence number {i}." for i in range(100)]
+
+    def _fill_and_clear() -> int:
+        for t in texts:
+            reader.add_to_queue(t)
+        size = len(reader._text_queue)
+        reader.clear_queue()
+        return size
+
+    size = benchmark(_fill_and_clear)
+    assert size == 100
+
+
+@pytest.mark.benchmark(group="queue")
+def test_bench_clear_queue_prefilled(
+    benchmark, mocked_reader_provider: Any
+) -> None:
+    """Latency of clear_queue() in isolation on an already-filled 50-item queue."""
+    reader = _make_reader(mocked_reader_provider)
+
+    def _setup() -> None:
+        for i in range(50):
+            reader._text_queue.append(f"Item {i}.")
+
+    benchmark.pedantic(reader.clear_queue, setup=_setup, rounds=200)
+
+
+# ---------------------------------------------------------------------------
+# State-machine benchmarks
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.benchmark(group="state")
+def test_bench_state_transition_single(
+    benchmark, mocked_reader_provider: Any
+) -> None:
+    """Latency of one _set_state call including blinker signal dispatch."""
+    reader = _make_reader(mocked_reader_provider)
+
+    def _toggle() -> None:
+        reader._set_state(ReaderState.READING)
+        reader._set_state(ReaderState.IDLE)
+
+    benchmark(_toggle)
+    assert reader.state == ReaderState.IDLE
+
+
+@pytest.mark.benchmark(group="state")
+def test_bench_state_full_cycle(
+    benchmark, mocked_reader_provider: Any
+) -> None:
+    """Latency of a complete IDLE -> READING -> PAUSED -> STOPPED -> IDLE cycle."""
+    reader = _make_reader(mocked_reader_provider)
+
+    def _cycle() -> None:
+        reader._set_state(ReaderState.READING)
+        reader._set_state(ReaderState.PAUSED)
+        reader._set_state(ReaderState.STOPPED)
+        reader._set_state(ReaderState.IDLE)
+
+    benchmark(_cycle)
+    assert reader.state == ReaderState.IDLE
+
+
+@pytest.mark.benchmark(group="state")
+def test_bench_reader_construction(
+    benchmark, mocked_reader_provider: Any
+) -> None:
+    """Overhead of constructing a TextReaderService (includes signal setup)."""
+
+    def _create() -> TextReaderService:
+        return TextReaderService(provider=mocked_reader_provider, show_ui=False)
+
+    reader = benchmark(_create)
+    assert reader.state == ReaderState.IDLE

--- a/benchmarks/bench_synthesis.py
+++ b/benchmarks/bench_synthesis.py
@@ -1,0 +1,108 @@
+"""
+Synthesis dispatch benchmarks.
+
+Measures the async-dispatch overhead of synthesize() and streaming
+synthesis using a zero-latency mock provider. No models or GPU required;
+safe to run in CI.
+
+Run with:
+    uv run pytest benchmarks/ --benchmark-only -v
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import numpy as np
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _run_synthesize(provider: Any, text: str) -> np.ndarray:
+    """Dispatch synthesize() and block until the coroutine completes."""
+    return asyncio.get_event_loop().run_until_complete(provider.synthesize(text))
+
+
+def _run_list_voices(provider: Any) -> list[str]:
+    """Dispatch list_voices() and block until the coroutine completes."""
+    return asyncio.get_event_loop().run_until_complete(provider.list_voices())
+
+
+async def _collect_stream(provider: Any, text: str) -> list[np.ndarray]:
+    return [chunk async for chunk in provider.synthesize_streaming(text)]
+
+
+def _run_stream(provider: Any, text: str) -> list[np.ndarray]:
+    """Collect all streaming chunks from synthesize_streaming()."""
+    return asyncio.get_event_loop().run_until_complete(
+        _collect_stream(provider, text)
+    )
+
+
+# ---------------------------------------------------------------------------
+# Latency benchmarks
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.benchmark(group="synthesis")
+def test_bench_synthesize_short_text(benchmark, benchmark_provider: Any) -> None:
+    """Baseline: synthesize() dispatch latency for a short phrase."""
+    result = benchmark(_run_synthesize, benchmark_provider, "Hello world.")
+    assert isinstance(result, np.ndarray)
+
+
+@pytest.mark.benchmark(group="synthesis")
+def test_bench_synthesize_medium_text(benchmark, benchmark_provider: Any) -> None:
+    """Synthesize dispatch latency for a medium-length sentence."""
+    text = "The quick brown fox jumps over the lazy dog. " * 3
+    result = benchmark(_run_synthesize, benchmark_provider, text)
+    assert isinstance(result, np.ndarray)
+
+
+@pytest.mark.benchmark(group="synthesis")
+def test_bench_synthesize_long_text(benchmark, benchmark_provider: Any) -> None:
+    """Synthesize dispatch latency for a long paragraph."""
+    text = (
+        "Performance testing ensures that our TTS system meets latency requirements. "
+        "Every text processing step adds overhead that accumulates at scale. "
+    ) * 5
+    result = benchmark(_run_synthesize, benchmark_provider, text)
+    assert isinstance(result, np.ndarray)
+
+
+@pytest.mark.benchmark(group="synthesis")
+def test_bench_synthesize_list_voices(benchmark, benchmark_provider: Any) -> None:
+    """Overhead of list_voices() dispatch."""
+    result = benchmark(_run_list_voices, benchmark_provider)
+    assert len(result) == 2
+
+
+@pytest.mark.benchmark(group="streaming")
+def test_bench_streaming_chunk_dispatch(benchmark, benchmark_provider: Any) -> None:
+    """Overhead of collecting all chunks from synthesize_streaming()."""
+    result = benchmark(_run_stream, benchmark_provider, "Hello streaming world.")
+    # BenchmarkProvider yields exactly 3 chunks
+    assert len(result) == 3
+
+
+@pytest.mark.benchmark(group="streaming")
+def test_bench_audio_concat_from_chunks(
+    benchmark, sample_audio_5s: np.ndarray
+) -> None:
+    """Overhead of assembling streaming chunks into a single array (numpy concat)."""
+    chunk_size = 4800
+    chunks = [
+        sample_audio_5s[i : i + chunk_size]
+        for i in range(0, len(sample_audio_5s), chunk_size)
+    ]
+
+    def _assemble() -> np.ndarray:
+        return np.concatenate(chunks)
+
+    result = benchmark(_assemble)
+    assert len(result) == len(sample_audio_5s)

--- a/benchmarks/conftest.py
+++ b/benchmarks/conftest.py
@@ -1,0 +1,88 @@
+"""Shared fixtures for TTS benchmarks."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import numpy as np
+import pytest
+
+from champi_tts.core.base_config import BaseTTSConfig
+from champi_tts.core.base_provider import BaseTTSProvider
+
+
+class BenchmarkConfig(BaseTTSConfig):
+    """Minimal config for benchmarks — no model or GPU required."""
+
+    @classmethod
+    def from_env(cls) -> "BenchmarkConfig":
+        return cls()
+
+    def validate(self) -> bool:
+        return True
+
+
+class BenchmarkProvider(BaseTTSProvider):
+    """Zero-latency mock provider for measuring dispatch overhead."""
+
+    def __init__(self) -> None:
+        super().__init__(BenchmarkConfig())
+
+    async def initialize(self) -> None:
+        self._initialized = True
+
+    async def shutdown(self) -> None:
+        self._initialized = False
+
+    async def synthesize(
+        self,
+        text: str,
+        voice: str | None = None,
+        speed: float | None = None,
+        **kwargs,
+    ) -> np.ndarray:
+        return np.zeros(1000, dtype=np.float32)
+
+    async def synthesize_streaming(
+        self,
+        text: str,
+        voice: str | None = None,
+        speed: float | None = None,
+        **kwargs,
+    ):
+        for _ in range(3):
+            yield np.zeros(100, dtype=np.float32)
+
+    async def list_voices(self) -> list[str]:
+        return ["voice1", "voice2"]
+
+    async def interrupt(self) -> None:
+        self._is_speaking = False
+
+
+@pytest.fixture(scope="session")
+def sample_audio_1s() -> np.ndarray:
+    """One second of 440 Hz sine at 24 kHz, float32."""
+    t = np.linspace(0, 1.0, 24000, endpoint=False)
+    return np.sin(2 * np.pi * 440 * t).astype(np.float32)
+
+
+@pytest.fixture(scope="session")
+def sample_audio_5s() -> np.ndarray:
+    """Five seconds of 440 Hz sine at 24 kHz, float32."""
+    t = np.linspace(0, 5.0, 120000, endpoint=False)
+    return np.sin(2 * np.pi * 440 * t).astype(np.float32)
+
+
+@pytest.fixture
+def benchmark_provider() -> BenchmarkProvider:
+    """Fresh BenchmarkProvider instance per test."""
+    return BenchmarkProvider()
+
+
+@pytest.fixture
+def mocked_reader_provider() -> MagicMock:
+    """Minimal MagicMock satisfying TextReaderService's constructor requirements."""
+    provider = MagicMock()
+    provider.config.sample_rate = 24000
+    return provider

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -302,7 +302,7 @@ disable_error_code = ["arg-type", "attr-defined", "no-any-return", "override", "
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
-python_files = "test_*.py"
+python_files = "test_*.py bench_*.py"
 python_classes = "Test*"
 python_functions = "test_*"
 addopts = "-v --durations=10 --cov=src/champi_tts --cov-report=xml --cov-report=term --cov-fail-under=70"


### PR DESCRIPTION
## Summary
- Add `benchmarks/conftest.py`: shared fixtures (`BenchmarkProvider`, `BenchmarkConfig`, `mocked_reader_provider`, audio arrays)
- Add `benchmarks/bench_synthesis.py`: 6 benchmarks covering `synthesize()` dispatch for short/medium/long text, `list_voices()`, streaming chunk collection, and numpy chunk assembly
- Add `benchmarks/bench_reader.py`: 6 benchmarks covering queue add/batch/clear, state transitions, and `TextReaderService` construction cost
- Add `benchmarks/bench_imports.py`: 4 benchmarks covering reimport timing, lazy loading verification (torch/kokoro absent), `list_providers()` overhead, and `KokoroConfig` construction
- Update `pyproject.toml`: add `bench_*.py` to `python_files` so `pytest benchmarks/` discovers the files

## Test plan
- [ ] `uv run pytest benchmarks/ --benchmark-only -v` passes all 16 benchmarks
- [ ] `ruff check benchmarks/` reports no issues
- [ ] No GPU, model download, or audio hardware required (all mocked)

Closes #19