### PR TITLE
docs: add migration guide from legacy kokoro_svc API

### DIFF
--- a/docs/migration.md
+++ b/docs/migration.md
@@ -1,4 +1,4 @@
-# Migration Guide: kokoro_svc → Champi TTS
+# Migration Guide: mcp_champi.kokoro_svc to champi_tts
 
 Complete migration guide for moving from `mcp_champi.kokoro_svc` to `champi_tts`.
 
@@ -6,15 +6,19 @@ Complete migration guide for moving from `mcp_champi.kokoro_svc` to `champi_tts`
 
 ## Overview
 
-Champi TTS is a modular, multi-provider text-to-speech library that provides:
+`champi_tts` is a modular, multi-provider text-to-speech library that replaces the
+tightly-coupled `mcp_champi.kokoro_svc` with a clean provider/adapter architecture.
 
-- Multi-provider TTS support (Kokoro, with OpenAI/ElevenLabs support planned)
-- Text reading service with pause/resume/stop controls
-- Visual UI indicator using ImGui/GLFW
-- CLI interface with rich terminal output
-- Event-driven architecture for state tracking
+Key improvements:
 
-This guide will help you migrate from the older `kokoro_svc` implementation.
+- **Multi-provider support**: Kokoro today, OpenAI and ElevenLabs coming soon
+- **Unified interface**: `BaseTTSProvider` contract across all backends
+- **Full reader service**: pause, resume, stop, queue management, and interruption
+- **Async context manager**: automatic lifecycle management
+- **Streaming synthesis**: chunk-by-chunk audio generation
+- **Visual UI indicator**: optional GLFW/ImGui overlay for reading status
+- **CLI tool**: `champi-tts` command for synthesis and file reading
+- **Lazy loading**: heavy dependencies (torch, kokoro) loaded on first use
 
 ---
 
@@ -26,19 +30,19 @@ This guide will help you migrate from the older `kokoro_svc` implementation.
 pip install champi-tts
 ```
 
-### Basic Usage
+### Minimal migration
 
-**Old Way (kokoro_svc):**
+**Before (`mcp_champi.kokoro_svc`):**
 
 ```python
-from kokoro_svc import KokoroService
+from mcp_champi.kokoro_svc import KokoroService
 
 service = KokoroService()
 await service.initialize()
 audio = await service.synthesize("Hello, world!")
 ```
 
-**New Way (Champi TTS):**
+**After (`champi_tts`):**
 
 ```python
 from champi_tts import get_provider
@@ -46,6 +50,16 @@ from champi_tts import get_provider
 provider = get_provider()
 await provider.initialize()
 audio = await provider.synthesize("Hello, world!")
+await provider.shutdown()
+```
+
+Or with automatic lifecycle management:
+
+```python
+from champi_tts import get_provider
+
+async with get_provider() as provider:
+    audio = await provider.synthesize("Hello, world!")
 ```
 
 ---
@@ -57,7 +71,7 @@ audio = await provider.synthesize("Hello, world!")
 - Python 3.12+
 - GPU (optional, for faster synthesis)
 
-### Install Command
+### Install options
 
 ```bash
 # Basic installation
@@ -66,58 +80,55 @@ pip install champi-tts
 # With development dependencies
 pip install "champi-tts[dev]"
 
-# With UI support
+# With UI support (GLFW/ImGui)
 pip install "champi-tts[ui]"
-```
 
-### Configuration
-
-Create a `.env` file for configuration:
-
-```env
-# Kokoro TTS settings
-CHAMPI_KOKORO_DEFAULT_VOICE=af_bella
-CHAMPI_KOKORO_DEFAULT_SPEED=1.1
-CHAMPI_KOKORO_USE_GPU=true
-
-# Model paths
-CHAMPI_KOKORO_MODEL_PATH=/path/to/models
-CHAMPI_KOKORO_CACHE_PATH=/path/to/cache
+# Development install from source
+git clone https://github.com/champi-ai/champi-tts.git
+cd champi-tts
+uv sync --extra dev
 ```
 
 ---
 
 ## API Migration
 
-### Provider Instantiation
+### Provider instantiation
 
-**Before (kokoro_svc):**
+**Before:**
 
 ```python
-from kokoro_svc import KokoroService, KokoroConfig
+from mcp_champi.kokoro_svc import KokoroService, KokoroConfig
 
 config = KokoroConfig(
     default_voice="af_bella",
     default_speed=1.1,
     model_path="./models/kokoro"
 )
-
 service = KokoroService(config)
+await service.initialize()
 ```
 
-**After (Champi TTS):**
+**After:**
 
 ```python
 from champi_tts import get_provider
 from champi_tts.providers.kokoro import KokoroConfig
 
 config = KokoroConfig(
-    default_voice="af_bella",
+    default_voice="am_adam",
     default_speed=1.1,
-    use_gpu=True
+    use_gpu=True,
+    model_dir="./models/kokoro"   # was model_path
 )
-
 provider = get_provider("kokoro", config=config)
+await provider.initialize()
+```
+
+Config fields can also be passed directly as kwargs:
+
+```python
+provider = get_provider("kokoro", default_voice="am_adam", use_gpu=True)
 ```
 
 ### Synthesis
@@ -125,25 +136,29 @@ provider = get_provider("kokoro", config=config)
 **Before:**
 
 ```python
-async def synthesize(service, text, voice=None, speed=1.0):
-    audio = await service.synthesize(text=text, voice=voice, speed=speed)
-    return audio
+audio = await service.synthesize(text="Hello, world!", voice="af_bella", speed=1.0)
 ```
 
 **After:**
 
 ```python
-async def synthesize(provider, text, voice=None, speed=1.0):
-    audio = await provider.synthesize(text=text, voice=voice, speed=speed)
-    return audio
+audio = await provider.synthesize(text="Hello, world!", voice="am_adam", speed=1.0)
 ```
 
-**Key Differences:**
-- Method signature is identical
-- Provider object replaces service object
-- Same return type (numpy array)
+The method signature is identical. The return type is a `numpy.ndarray` in both cases.
 
-### Voice Listing
+### Streaming synthesis (new)
+
+`mcp_champi.kokoro_svc` did not support streaming. `champi_tts` adds
+`synthesize_streaming` which yields audio chunks as they are generated:
+
+```python
+async for chunk in provider.synthesize_streaming("A long piece of text..."):
+    # process or play each chunk immediately
+    pass
+```
+
+### Listing voices
 
 **Before:**
 
@@ -157,40 +172,156 @@ voices = await service.list_voices()
 voices = await provider.list_voices()
 ```
 
-### Reading Text Files
+The return type is `list[str]`. Voice names follow the `<language_gender>_<name>` pattern:
 
-**Before (if implemented in kokoro_svc):**
+| Prefix | Language / Gender |
+|--------|-------------------|
+| `af_`  | American English, Female |
+| `am_`  | American English, Male |
+| `bf_`  | British English, Female |
+| `bm_`  | British English, Male |
+| `ef_`  | Spanish, Female |
+| `em_`  | Spanish, Male |
+| `ff_`  | French, Female |
+
+Default voice changed from `af_bella` to `am_adam`.
+
+### Interruption
+
+**Before:**
 
 ```python
-from kokoro_svc import KokoroService
+await service.cancel()
+```
+
+**After:**
+
+```python
+await provider.interrupt()
+```
+
+### Shutdown
+
+**Before:**
+
+```python
+await service.shutdown()
+```
+
+**After:**
+
+```python
+await provider.shutdown()
+# or use the async context manager for automatic shutdown
+```
+
+---
+
+## Reader Service Migration
+
+`mcp_champi.kokoro_svc` provided basic `read_text` and `read_file` methods on
+`KokoroService`. `champi_tts` separates this concern into `TextReaderService` with
+full queue management and event signals.
+
+### Reading text
+
+**Before:**
+
+```python
+from mcp_champi.kokoro_svc import KokoroService
 
 service = KokoroService()
 await service.initialize()
-
-# Read and play text
 await service.read_text("Hello world")
 ```
 
-**After (Champi TTS):**
+**After:**
 
 ```python
 from champi_tts import get_reader
 
 reader = get_reader("kokoro")
+await reader.provider.initialize()
 await reader.read_text("Hello world")
+await reader.provider.shutdown()
+```
 
-# With file reading
-await reader.read_file("document.txt")
+Or with automatic lifecycle via the async context manager:
 
-# With pause/resume
+```python
+from champi_tts import get_reader
+
+async with get_reader("kokoro") as reader:
+    await reader.read_text("Hello world")
+```
+
+### Reading files
+
+**Before:**
+
+```python
+await service.read_file("document.txt")
+```
+
+**After:**
+
+```python
+await reader.read_file("document.txt", voice="am_adam")
+```
+
+Files are split on double newlines and read paragraph by paragraph, with a 0.5 s
+pause between paragraphs.
+
+### Playback control
+
+**Before:**
+
+```python
+await service.pause()
+await service.resume()
+await service.stop()
+```
+
+**After:**
+
+```python
 await reader.pause()
 await reader.resume()
-
-# Stop reading
 await reader.stop()
 ```
 
-### Event Handling
+### Queue management (new)
+
+`mcp_champi.kokoro_svc` had no queue. `champi_tts` adds a text queue:
+
+```python
+reader.add_to_queue("First paragraph")
+reader.add_to_queue("Second paragraph")
+await reader.read_queue(voice="am_adam")
+
+# Clear the queue at any time
+reader.clear_queue()
+```
+
+### Reader state
+
+```python
+from champi_tts import ReaderState
+
+if reader.state == ReaderState.READING:
+    print("Currently reading")
+elif reader.state == ReaderState.PAUSED:
+    print("Paused")
+```
+
+Available states: `IDLE`, `READING`, `PAUSED`, `STOPPED`.
+
+---
+
+## Event Handling Migration
+
+`mcp_champi.kokoro_svc` used decorator-based callbacks. `champi_tts` uses
+[blinker](https://blinker.readthedocs.io/) signals.
 
 **Before:**
 
@@ -199,7 +330,7 @@ await reader.stop()
 def on_started(text):
     print(f"Started: {text}")
 
-@service.on_completed  
+@service.on_completed
 def on_completed():
     print("Completed")
 ```
@@ -211,65 +342,39 @@ from champi_tts import get_reader
 
 reader = get_reader("kokoro")
 
-# Subscribe to events
-reader.on_reading_started.connect(lambda **kw: print(f"Started: {kw.get('text')}"))
-reader.on_reading_completed.connect(lambda **kw: print("Completed"))
-reader.on_error.connect(lambda **kw: print(f"Error: {kw.get('error')}"))
+def on_started(sender, **kw):
+    print(f"Started: {kw.get('text', '')}")
+
+def on_completed(sender, **kw):
+    print("Completed")
+
+def on_error(sender, **kw):
+    print(f"Error: {kw.get('error', '')}")
+
+reader.on_reading_started.connect(on_started)
+reader.on_reading_completed.connect(on_completed)
+reader.on_error.connect(on_error)
 ```
 
----
+All available signals on `TextReaderService`:
 
-## Breaking Changes
-
-### 1. Class Structure
-
-**Old:** `KokoroService` inherited directly from base class
-
-**New:** Uses adapter pattern for type compliance
-
-```python
-# Old direct inheritance
-class KokoroService(BaseService):
-    pass
-
-# New adapter pattern
-class KokoroProviderAdapter(BaseTTSProvider):
-    def __init__(self, config):
-        self._kokoro = OriginalKokoroProvider(config)
-```
-
-**Impact:** None for users - the adapter makes KokoroProvider conform to the base interface.
-
-### 2. Async Context Manager
-
-**New:** Added async context manager support
-
-```python
-# New way (recommended)
-async with get_provider("kokoro") as provider:
-    audio = await provider.synthesize("Hello")
-# Automatic cleanup on exit
-```
-
-### 3. Reader Service
-
-**New:** Full reader service with queue management
-
-```python
-# New features
-reader.add_to_queue("Text 1")
-reader.add_to_queue("Text 2")
-await reader.read_queue()  # Read all queued texts
-reader.clear_queue()
-```
+| Signal | Kwargs |
+|--------|--------|
+| `on_reading_started` | `text` |
+| `on_reading_paused` | — |
+| `on_reading_resumed` | — |
+| `on_reading_stopped` | — |
+| `on_reading_completed` | `text` |
+| `on_state_changed` | `old_state`, `new_state` |
+| `on_error` | `error` |
 
 ---
 
 ## Configuration Migration
 
-### Environment Variables
+### Environment variables
 
-**Old (.env for kokoro_svc):**
+**Before (`mcp_champi.kokoro_svc`):**
 
 ```env
 KOKORO_DEFAULT_VOICE=af_bella
@@ -279,100 +384,127 @@ KOKORO_MODEL_PATH=/models
 KOKORO_CACHE_PATH=/cache
 ```
 
-**New (.env for Champi TTS):**
+**After (`champi_tts`):**
 
 ```env
-# Same keys work, prefixed with CHAMPI_
-CHAMPI_KOKORO_DEFAULT_VOICE=af_bella
-CHAMPI_KOKORO_DEFAULT_SPEED=1.1
-CHAMPI_KOKORO_USE_GPU=true
-CHAMPI_KOKORO_MODEL_PATH=/models
-CHAMPI_KOKORO_CACHE_PATH=/cache
+KOKORO_DEFAULT_VOICE=am_adam
+KOKORO_DEFAULT_SPEED=1.1
+KOKORO_USE_GPU=true
+KOKORO_FORCE_CPU=false
+KOKORO_DEFAULT_LANGUAGE=a
+KOKORO_MODEL_DIR=/models
+KOKORO_VOICE_DIR=/voices
+KOKORO_CACHE_DIR=/cache
+KOKORO_NORMALIZE_TEXT=true
+KOKORO_WARMUP_ON_INIT=true
+KOKORO_AUTO_DOWNLOAD=true
 ```
 
-### Config Class
-
-**Old:**
+Load from environment explicitly:
 
 ```python
-class KokoroConfig(BaseConfig):
-    default_voice: str = "af_bella"
-    default_speed: float = 1.0
-    model_path: str = "./models/kokoro"
+from champi_tts.providers.kokoro import KokoroConfig
+
+config = KokoroConfig.from_env()
+provider = get_provider("kokoro", config=config)
 ```
 
-**New:**
+### Config class changes
+
+| Old field (`KokoroConfig`) | New field (`KokoroConfig`) | Notes |
+|---------------------------|---------------------------|-------|
+| `model_path` | `model_dir` | Directory, not file path |
+| `cache_path` | `cache_dir` | Directory, not file path |
+| `voice_path` | `voice_dir` | Directory for `.pt` files |
+| — | `default_language` | Language code, default `"a"` (US English) |
+| — | `force_cpu` | Explicitly disable GPU even if available |
+| — | `advanced_normalization` | Extended text normalization pipeline |
+| — | `memory_management` | Enable memory management optimisations |
+| — | `max_text_length` | Maximum characters per synthesis call |
+
+Language codes for `default_language`:
+
+| Code | Language |
+|------|----------|
+| `a` | American English (default) |
+| `b` | British English |
+| `e` | Spanish |
+| `f` | French |
+| `h` | Hindi |
+| `i` | Italian |
+| `j` | Japanese |
+| `p` | Brazilian Portuguese |
+| `z` | Mandarin Chinese |
+
+### Configuration presets (new)
 
 ```python
-class KokoroConfig(BaseTTSConfig):
-    default_voice: str = "af_bella"
-    default_speed: float = 1.0
-    use_gpu: bool = False
+from champi_tts.providers.kokoro import KokoroConfig
+
+# High performance (GPU, warmup, advanced normalization)
+config = KokoroConfig.performance()
+
+# High quality (GPU, longer chunks, retry on failure)
+config = KokoroConfig.quality()
+
+# CPU only (no GPU, no warmup, smaller chunks)
+config = KokoroConfig.cpu_only()
+
+# Minimal resources (CPU, no normalization, no auto-download)
+config = KokoroConfig.minimal()
 ```
 
 ---
 
-## Audio Processing
+## Audio Processing Migration
 
-### Playback
+### Saving audio
 
-**Old:**
+**Before:**
 
 ```python
-from kokoro_svc import AudioPlayer
+from mcp_champi.kokoro_svc import AudioPlayer
 
 player = AudioPlayer(sample_rate=22050)
 await player.play(audio)
 ```
 
-**New:**
+**After:**
 
 ```python
 from champi_tts.core.audio import AudioPlayer
 
-player = AudioPlayer(sample_rate=22050)
-await player.play(audio, blocking=False)
+player = AudioPlayer(sample_rate=24000)  # Kokoro outputs at 24 kHz
+await player.play(audio, blocking=True)
 ```
 
-### Saving Audio
+The default sample rate changed from 22050 Hz to 24000 Hz.
 
-**New:**
+### Saving audio to file
+
+**Before:**
+
+There was no built-in save function.
+
+**After:**
 
 ```python
 from champi_tts.core.audio import save_audio
 
-await save_audio(audio, "output.wav", sample_rate=22050)
+await save_audio(audio, "output.wav", sample_rate=provider.config.sample_rate)
 ```
+
+Supported formats: `wav`, `mp3`, `opus`, `flac`, `pcm`.
 
 ---
 
-## Voice Files
+## Complete Migration Example
 
-### Setup
-
-Voice files are included in the package. No additional download needed for default voices.
-
-### Custom Voices
-
-To add custom voices:
+**Before (`mcp_champi.kokoro_svc`):**
 
 ```python
-from champi_tts.providers.kokoro import VoiceManager
-
-vm = VoiceManager(model_path="./models")
-vm.download_voice("custom_voice")
-```
-
----
-
-## Code Examples
-
-### Complete Migration Example
-
-**Before (kokoro_svc):**
-
-```python
-from kokoro_svc import KokoroService, KokoroConfig
+import asyncio
+from mcp_champi.kokoro_svc import KokoroService, KokoroConfig
 
 async def main():
     config = KokoroConfig(
@@ -381,198 +513,270 @@ async def main():
     )
     service = KokoroService(config)
     await service.initialize()
-    
+
     try:
-        # Synthesize
         audio = await service.synthesize("Hello, world!")
         await service.play_audio(audio)
-        
-        # Read file
         await service.read_file("document.txt")
-        
-        # Listen for events
+
         for event in service.on_events():
             if event.type == "completed":
                 print("Done")
     finally:
         await service.shutdown()
+
+asyncio.run(main())
 ```
 
-**After (Champi TTS):**
+**After (`champi_tts`):**
 
 ```python
+import asyncio
 from champi_tts import get_provider, get_reader
 from champi_tts.core.audio import save_audio
-from champi_tts.ui import TTSIndicatorUI, TTSState
 
 async def main():
-    # Get provider
-    provider = get_provider()
-    
-    async with provider:
-        try:
-            # Synthesize
-            audio = await provider.synthesize("Hello, world!")
-            await save_audio(audio, "hello.wav")
-            
-            # Create reader with UI
-            reader = get_reader("kokoro", show_ui=True)
-            
-            # Subscribe to events
-            def on_started(sender, **kw):
-                print(f"Started: {kw.get('text', '')[:50]}. ..")
-            
-            def on_completed(sender, **kw):
-                print("Reading completed")
-            
-            def on_error(sender, **kw):
-                print(f"Error: {kw.get('error', '')}")
-            
-            reader.on_reading_started.connect(on_started)
-            reader.on_reading_completed.connect(on_completed)
-            reader.on_error.connect(on_error)
-            
-            # Read text
-            await reader.read_text("This is a test of Champi TTS")
-            
-            # Queue management
-            reader.add_to_queue("Second paragraph")
-            await reader.read_queue()
-            
-        except Exception as e:
-            print(f"Error: {e}")
-            if reader._ui:
-                reader._ui.update_state(TTSState.ERROR, str(e))
+    # Synthesize and save
+    async with get_provider() as provider:
+        audio = await provider.synthesize("Hello, world!")
+        await save_audio(audio, "hello.wav", sample_rate=provider.config.sample_rate)
+
+    # Read a file with event callbacks
+    async with get_reader("kokoro") as reader:
+        def on_started(sender, **kw):
+            print(f"Started: {kw.get('text', '')[:50]}...")
+
+        def on_completed(sender, **kw):
+            print("Reading completed")
+
+        def on_error(sender, **kw):
+            print(f"Error: {kw.get('error', '')}")
+
+        reader.on_reading_started.connect(on_started)
+        reader.on_reading_completed.connect(on_completed)
+        reader.on_error.connect(on_error)
+
+        await reader.read_file("document.txt", voice="am_adam")
+
+asyncio.run(main())
+```
+
+---
+
+## CLI Migration
+
+`mcp_champi.kokoro_svc` had no CLI. `champi_tts` ships the `champi-tts` command:
+
+```bash
+# Synthesize and play
+champi-tts synthesize "Hello, world!" --voice am_adam
+
+# Synthesize and save to file (no playback)
+champi-tts synthesize "Hello, world!" --output hello.wav --no-play
+
+# Read a text file
+champi-tts read document.txt --voice am_adam
+
+# Read with visual UI indicator
+champi-tts read document.txt --show-ui
+
+# Read inline text
+champi-tts read --text "This is a test" --voice am_adam
+
+# Interactive mode (SPACE to pause/resume, S to stop, Q to quit)
+champi-tts read document.txt --interactive --show-ui
+
+# List available voices
+champi-tts list-voices
+
+# Show version
+champi-tts version
+
+# Test the UI indicator
+champi-tts test-ui
+```
+
+---
+
+## Breaking Changes
+
+### 1. Import path
+
+```python
+# Before
+from mcp_champi.kokoro_svc import KokoroService
+
+# After
+from champi_tts import get_provider
+```
+
+### 2. Class name
+
+`KokoroService` is replaced by `KokoroProvider` (accessed via `get_provider()`).
+Direct instantiation is possible but the factory function is recommended:
+
+```python
+# Factory (recommended)
+from champi_tts import get_provider
+provider = get_provider("kokoro")
+
+# Direct (not recommended for user code)
+from champi_tts.providers.kokoro import KokoroProvider
+from champi_tts.providers.kokoro.adapter import KokoroProviderAdapter
+```
+
+### 3. Config field names
+
+`model_path` and `cache_path` are renamed to `model_dir` and `cache_dir` to
+reflect that they are directory paths, not file paths.
+
+### 4. Default voice
+
+The default voice changed from `af_bella` to `am_adam`. Set `default_voice`
+explicitly if you rely on a specific voice:
+
+```python
+config = KokoroConfig(default_voice="af_bella")
+```
+
+### 5. Default sample rate
+
+Sample rate changed from 22050 Hz to 24000 Hz. Update any downstream audio
+processing that assumed the old rate.
+
+### 6. Event system
+
+Decorator-based callbacks (`@service.on_started`) are replaced by blinker
+signals (`.connect(handler)`). Signal handlers receive `sender` as their first
+positional argument plus keyword arguments:
+
+```python
+def handler(sender, **kwargs):
+    ...
+
+reader.on_reading_started.connect(handler)
+```
+
+### 7. Explicit provider initialization
+
+`get_reader()` does not auto-initialize the provider. Call
+`await reader.provider.initialize()` before reading, or use the async context
+manager which handles this automatically:
+
+```python
+async with get_reader("kokoro") as reader:
+    await reader.read_text("Hello")
+```
+
+---
+
+## Model and Voice Setup
+
+Kokoro model files are downloaded automatically on first use when
+`auto_download_model=True` (the default). To download manually:
+
+```python
+from champi_tts.providers.kokoro import ModelDownloader
+
+model_path, config_path = ModelDownloader.download_model(output_dir="./models/kokoro")
+```
+
+Voice files (`.pt` tensors) live in the voice directory. Set it explicitly or
+let the provider use its default:
+
+```python
+from champi_tts.providers.kokoro import KokoroConfig, VoiceManager
+
+config = KokoroConfig(voice_dir="./voices")
+VoiceManager.setup_voice_directory("./voices")
+
+# List voices in a directory
+voices = VoiceManager.list_voices("./voices")
 ```
 
 ---
 
 ## Troubleshooting
 
-### Issue: "ModuleNotFoundError: No module named 'champi_tts'"
+### ModuleNotFoundError: No module named 'champi_tts'
 
-**Solution:**
+Install the package:
 
 ```bash
+pip install champi-tts
+# or for development
 pip install -e ".[dev]"
 ```
 
-### Issue: "Voice not found: af_bella"
+### Voice not found
 
-**Solution:**
-
-Ensure model files are downloaded:
+List the voices that are available to your provider:
 
 ```bash
-champi-tts download-voices
+champi-tts list-voices
 ```
 
-### Issue: "CUDA out of memory"
-
-**Solution:**
-
-Disable GPU or use smaller batch size:
+Or programmatically:
 
 ```python
-config = KokoroConfig(use_gpu=False)
+voices = await provider.list_voices()
+print(voices)
 ```
 
-### Issue: UI not showing
+If the voice directory is empty, download model files first:
 
-**Solution:**
+```python
+from champi_tts.providers.kokoro import ModelDownloader
+ModelDownloader.download_model(output_dir="./models/kokoro")
+```
 
-UI dependencies are optional:
+### CUDA out of memory
+
+Disable GPU acceleration:
+
+```python
+from champi_tts.providers.kokoro import KokoroConfig
+config = KokoroConfig(use_gpu=False, force_cpu=True)
+provider = get_provider("kokoro", config=config)
+```
+
+Or use the `cpu_only` preset:
+
+```python
+from champi_tts.providers.kokoro import KokoroConfigPresets
+config = KokoroConfigPresets.cpu_only()
+```
+
+### UI not showing
+
+Install optional UI dependencies:
 
 ```bash
 pip install "champi-tts[ui]"
 ```
 
-Or disable UI:
+Or disable UI entirely:
 
 ```python
 reader = get_reader("kokoro", show_ui=False)
 ```
 
----
+### AttributeError on KokoroConfig fields
 
-## Performance Considerations
+Check that you are using the new field names:
 
-### Lazy Loading
-
-Heavy dependencies are loaded on first use:
-
-```python
-# torch and kokoro loaded on first synthesis() call
-# Not on import
-```
-
-### GPU Acceleration
-
-Enable GPU for faster synthesis:
-
-```python
-config = KokoroConfig(use_gpu=True)
-```
-
-### Caching
-
-Synthesized audio can be cached:
-
-```python
-config = KokoroConfig(
-    cache_path="./cache",
-    cache_ttl=3600  # Cache for 1 hour
-)
-```
-
----
-
-## Testing Your Migration
-
-### Run Tests
-
-```bash
-pytest tests/ -v
-```
-
-### Run Examples
-
-```bash
-# Basic synthesis
-champi-tts synthesize "Hello, world!"
-
-# Read file
-champi-tts read document.txt
-```
-
-### Run UI Test
-
-```bash
-champi-tts test-ui
-```
+| Old field | New field |
+|-----------|-----------|
+| `model_path` | `model_dir` |
+| `cache_path` | `cache_dir` |
+| `voice_path` | `voice_dir` |
 
 ---
 
 ## Resources
 
-- **API Reference:** `docs/api.md`
-- **Architecture:** `ARCHITECTURE.md`
-- **Examples:** `examples/` directory
-- **GitHub:** https://github.com/champi-ai/champi-tts
-
----
-
-## Support
-
-If you encounter issues during migration:
-
-1. Check the examples in `examples/`
-2. Review the API reference in `docs/api.md`
-3. Open an issue on GitHub
-4. Check existing issues for similar problems
-
----
-
-**Migration Complete!** 🎉
-
-Your code should now use Champi TTS. Enjoy the new features and improvements!
+- **API Reference**: `docs/api.md`
+- **User Guide**: `docs/USER_GUIDE.md`
+- **Troubleshooting**: `docs/TROUBLESHOOTING.md`
+- **Examples**: `examples/` directory
+- **GitHub**: https://github.com/champi-ai/champi-tts


### PR DESCRIPTION
## Summary
- Rewrite `docs/migration.md` with accurate API migration guide from `mcp_champi.kokoro_svc` to `champi_tts`
- Covers import changes, provider instantiation, synthesis, playback, and config patterns
- Includes before/after code examples for all major workflows

## Test plan
- [ ] `mkdocs build` succeeds with updated migration.md
- [ ] All code examples are valid against current champi_tts API

Closes #3