### PR TITLE
fix: lower genbadge version bound to match available releases

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,7 +95,7 @@ dev = [
     "uv",
     "uv-build>=0.10.0",
     "hatching",
-    "genbadge[coverage]>=1.6.0",
+    "genbadge[coverage]>=1.1.0",
 ]
 
 # Test tools


### PR DESCRIPTION
## Summary
- `genbadge[coverage]>=1.6.0` does not exist (latest release is 1.1.3)
- Lower bound to `>=1.1.0` to fix dependency resolution failure on Python 3.13

## Test plan
- [ ] `uv sync --extra dev` resolves without errors on Python 3.12 and 3.13