### PR TITLE
feat(voices): add voice cache manager and CLI voice commands

### DIFF
--- a/src/champi_tts/cli/main.py
+++ b/src/champi_tts/cli/main.py
@@ -12,6 +12,10 @@ from rich.console import Console
 from rich.progress import Progress, SpinnerColumn, TextColumn
 
 from champi_tts import get_provider, get_reader
+from champi_tts.providers.kokoro.voice_manager import (
+    VOICES_CACHE_DIR,
+    list_cached_voices,
+)
 
 app = typer.Typer(
     name="champi-tts",
@@ -19,6 +23,9 @@ app = typer.Typer(
     add_completion=False,
 )
 console = Console()
+
+voices_app = typer.Typer(help="Manage cached voice files.")
+app.add_typer(voices_app, name="voices")
 
 
 @app.command()
@@ -284,6 +291,33 @@ def version():
     from champi_tts import __version__
 
     console.print(f"champi-tts version [cyan]{__version__}[/cyan]")
+
+
+@voices_app.command("list")
+def voices_list(
+    cache_dir: Path | None = typer.Option(
+        None, "--cache-dir", help="Override the voice cache directory."
+    ),
+) -> None:
+    """List voice files available in the cache directory."""
+    voices = list_cached_voices(cache_dir)
+    if not voices:
+        console.print("[yellow]No cached voices found.[/yellow]")
+        raise typer.Exit(0)
+    console.print("[bold]Cached voices:[/bold]")
+    for voice in voices:
+        console.print(f"  • {voice}")
+
+
+@voices_app.command("cache-dir")
+def voices_cache_dir(
+    cache_dir: Path | None = typer.Option(
+        None, "--cache-dir", help="Override the voice cache directory."
+    ),
+) -> None:
+    """Print the voice cache directory path."""
+    directory = cache_dir if cache_dir is not None else VOICES_CACHE_DIR
+    console.print(str(directory))
 
 
 def main():

--- a/src/champi_tts/providers/kokoro/voice_manager.py
+++ b/src/champi_tts/providers/kokoro/voice_manager.py
@@ -1,0 +1,47 @@
+"""
+Voice cache manager for Kokoro TTS.
+
+Resolves voice file paths within the user-level cache directory and
+provides utilities for listing cached voices. Voice files must be placed
+manually; this module handles path resolution and cache directory setup only.
+"""
+
+from pathlib import Path
+
+VOICES_CACHE_DIR: Path = Path.home() / ".cache" / "champi-tts" / "voices"
+
+
+def get_voice_path(voice_name: str, cache_dir: Path | None = None) -> Path:
+    """Return the expected path for a voice file in the cache directory.
+
+    The directory is created if it does not already exist.  The caller is
+    responsible for verifying that the returned path exists before use.
+
+    Args:
+        voice_name: Voice identifier without the ``.pt`` extension.
+        cache_dir: Override the default cache directory.  Defaults to
+            ``~/.cache/champi-tts/voices``.
+
+    Returns:
+        Path pointing to ``<cache_dir>/<voice_name>.pt``.
+    """
+    directory = cache_dir if cache_dir is not None else VOICES_CACHE_DIR
+    directory.mkdir(parents=True, exist_ok=True)
+    return directory / f"{voice_name}.pt"
+
+
+def list_cached_voices(cache_dir: Path | None = None) -> list[str]:
+    """List voice names available in the cache directory.
+
+    Args:
+        cache_dir: Override the default cache directory.  Defaults to
+            ``~/.cache/champi-tts/voices``.
+
+    Returns:
+        Sorted list of voice names (filenames without the ``.pt`` suffix).
+        Returns an empty list when the directory does not exist.
+    """
+    directory = cache_dir if cache_dir is not None else VOICES_CACHE_DIR
+    if not directory.is_dir():
+        return []
+    return sorted(p.stem for p in directory.iterdir() if p.suffix == ".pt")

--- a/src/champi_tts/providers/kokoro/voices/README.txt
+++ b/src/champi_tts/providers/kokoro/voices/README.txt
@@ -1,14 +1,40 @@
 Kokoro Voice Directory
 ====================
 
-Place your Kokoro voice files (.pt) in this directory.
+This directory is part of the source distribution and does not contain
+voice files. Voice files (.pt) are not bundled with the package.
 
-Voice files should be PyTorch tensors saved with torch.save().
-You can download voice files from the Kokoro project or create your own.
+Cache location
+--------------
 
-Example usage:
+Voice files are resolved from the user cache directory:
+
+    ~/.cache/champi-tts/voices/
+
+Place your Kokoro voice files (.pt) in that directory before use.
+
+CLI helpers
+-----------
+
+Print the cache directory path:
+
+    champi-tts voices cache-dir
+
+List voices already present in the cache:
+
+    champi-tts voices list
+
+Obtaining voice files
+---------------------
+
+Voice files are PyTorch tensors saved with torch.save(). Download them
+from the Kokoro project or create your own and place them in the cache
+directory shown above.
+
+Example filenames:
 - af_bella.pt
 - af_sarah.pt
 - am_adam.pt
 
-The voice name (filename without .pt) will be used to identify the voice.
+The voice name (filename without .pt) is used to identify the voice
+when calling synthesis commands.

--- a/tests/test_providers/test_voice_manager.py
+++ b/tests/test_providers/test_voice_manager.py
@@ -1,0 +1,90 @@
+"""
+Tests for the voice cache manager.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from champi_tts.providers.kokoro.voice_manager import (
+    VOICES_CACHE_DIR,
+    get_voice_path,
+    list_cached_voices,
+)
+
+
+class TestGetVoicePath:
+    """Tests for get_voice_path()."""
+
+    def test_returns_path_with_pt_extension(self, tmp_path: Path) -> None:
+        """get_voice_path() appends .pt to the voice name."""
+        result = get_voice_path("af_bella", cache_dir=tmp_path)
+        assert result.suffix == ".pt"
+        assert result.stem == "af_bella"
+
+    def test_path_is_inside_cache_dir(self, tmp_path: Path) -> None:
+        """Returned path is a direct child of the cache directory."""
+        result = get_voice_path("am_adam", cache_dir=tmp_path)
+        assert result.parent == tmp_path
+
+    def test_creates_cache_directory(self, tmp_path: Path) -> None:
+        """get_voice_path() creates the cache directory when it is absent."""
+        new_dir = tmp_path / "deep" / "voices"
+        assert not new_dir.exists()
+        get_voice_path("af_sarah", cache_dir=new_dir)
+        assert new_dir.is_dir()
+
+    def test_default_cache_dir_used_when_none(self) -> None:
+        """When cache_dir is None the default VOICES_CACHE_DIR is used."""
+        result = get_voice_path("af_sky")
+        assert result.parent == VOICES_CACHE_DIR
+
+    def test_full_path_is_correct(self, tmp_path: Path) -> None:
+        """Returned path equals <cache_dir>/<voice_name>.pt."""
+        expected = tmp_path / "bm_george.pt"
+        result = get_voice_path("bm_george", cache_dir=tmp_path)
+        assert result == expected
+
+
+class TestListCachedVoices:
+    """Tests for list_cached_voices()."""
+
+    def test_empty_directory_returns_empty_list(self, tmp_path: Path) -> None:
+        """No .pt files means an empty list is returned."""
+        assert list_cached_voices(cache_dir=tmp_path) == []
+
+    def test_lists_pt_files_without_extension(self, tmp_path: Path) -> None:
+        """Voice names are returned without the .pt suffix."""
+        (tmp_path / "af_bella.pt").touch()
+        (tmp_path / "am_adam.pt").touch()
+        result = list_cached_voices(cache_dir=tmp_path)
+        assert "af_bella" in result
+        assert "am_adam" in result
+
+    def test_ignores_non_pt_files(self, tmp_path: Path) -> None:
+        """Files with extensions other than .pt are not included."""
+        (tmp_path / "af_bella.pt").touch()
+        (tmp_path / "README.txt").touch()
+        (tmp_path / "config.json").touch()
+        result = list_cached_voices(cache_dir=tmp_path)
+        assert result == ["af_bella"]
+
+    def test_result_is_sorted(self, tmp_path: Path) -> None:
+        """Returned list is sorted alphabetically."""
+        for name in ["zz_voice.pt", "aa_voice.pt", "mm_voice.pt"]:
+            (tmp_path / name).touch()
+        result = list_cached_voices(cache_dir=tmp_path)
+        assert result == sorted(result)
+
+    def test_nonexistent_directory_returns_empty_list(self, tmp_path: Path) -> None:
+        """Missing cache directory returns an empty list rather than raising."""
+        missing = tmp_path / "does_not_exist"
+        assert list_cached_voices(cache_dir=missing) == []
+
+    def test_default_cache_dir_used_when_none(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """When cache_dir is None, VOICES_CACHE_DIR is consulted."""
+        import champi_tts.providers.kokoro.voice_manager as vm
+
+        fake_dir = Path("/nonexistent/fake")
+        monkeypatch.setattr(vm, "VOICES_CACHE_DIR", fake_dir)
+        assert list_cached_voices() == []


### PR DESCRIPTION
## Summary
- Add `src/champi_tts/providers/kokoro/voice_manager.py`: voice path resolution from `~/.cache/champi-tts/voices/`
- Add `champi-tts voices list` CLI command: list cached voices
- Add `champi-tts voices cache-dir` CLI command: print cache directory path
- Update `voices/README.txt` to document cache location and CLI helpers
- Add `tests/test_providers/test_voice_manager.py`: path resolution and cache listing tests

## Test plan
- [ ] `champi-tts voices cache-dir` prints the correct path
- [ ] `champi-tts voices list` lists .pt files in cache
- [ ] `uv run pytest tests/test_providers/test_voice_manager.py -v` passes

Closes #9