### PR TITLE
fix: resolve all ruff lint errors across codebase

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,7 +95,7 @@ dev = [
     "uv",
     "uv-build>=0.10.0",
     "hatching",
-    "genbadge[coverage]>=1.6.0",
+    "genbadge[coverage]>=1.1.0",
 ]
 
 # Test tools

--- a/src/champi_tts/cli/main.py
+++ b/src/champi_tts/cli/main.py
@@ -24,8 +24,9 @@ console = Console()
 @app.command()
 def synthesize(
     text: str = typer.Argument(..., help="Text to synthesize"),
-    output: Path
-    | None = typer.Option(None, "--output", "-o", help="Output audio file path"),
+    output: Path | None = typer.Option(
+        None, "--output", "-o", help="Output audio file path"
+    ),
     voice: str | None = typer.Option(None, "--voice", "-v", help="Voice to use"),
     speed: float = typer.Option(1.0, "--speed", "-s", help="Speech speed (0.5-2.0)"),
     provider: str = typer.Option(
@@ -81,8 +82,7 @@ def synthesize(
 @app.command()
 def read(
     file_path: Path | None = typer.Argument(None, help="Text file to read"),
-    text: str
-    | None = typer.Option(
+    text: str | None = typer.Option(
         None, "--text", "-t", help="Text to read (alternative to file)"
     ),
     voice: str | None = typer.Option(None, "--voice", "-v", help="Voice to use"),

--- a/src/champi_tts/core/audio_effects.py
+++ b/src/champi_tts/core/audio_effects.py
@@ -9,16 +9,12 @@ This module provides audio enhancement capabilities:
 - Compression
 """
 
-import asyncio
 from pathlib import Path
-from typing import Optional
 
 import numpy as np
 import scipy.signal as signal
-import soundfile as sf
-from loguru import logger
 
-from .audio import AudioPlayer, load_audio
+from .audio import load_audio
 
 
 class AudioProcessor:
@@ -89,7 +85,7 @@ class AudioProcessor:
         self,
         audio: np.ndarray,
         duration: float = 0.5,
-        sample_rate: Optional[int] = None,
+        sample_rate: int | None = None,
     ) -> np.ndarray:
         """
         Add silence before/after audio.
@@ -114,7 +110,7 @@ class AudioProcessor:
         self,
         audio: np.ndarray,
         fade_duration: float = 0.1,
-        sample_rate: Optional[int] = None,
+        sample_rate: int | None = None,
     ) -> np.ndarray:
         """
         Add fade in/out to audio.
@@ -152,7 +148,7 @@ class AudioProcessor:
         delay: float = 0.5,
         decay: float = 0.7,
         spread: float = 0.5,
-        sample_rate: Optional[int] = None,
+        sample_rate: int | None = None,
     ) -> np.ndarray:
         """
         Add echo effect to audio.
@@ -252,7 +248,7 @@ class AudioProcessor:
             Boosted audio
         """
         # Simple bass boost: amplify low frequencies
-        half_rate = self.sample_rate // 2
+        self.sample_rate // 2
         freq_range = int(100 * 2 * np.pi / self.sample_rate)
 
         low_freq_mask = np.arange(len(audio)) < freq_range
@@ -306,7 +302,7 @@ class AudioProcessor:
         audio: np.ndarray,
         decay: float = 1.5,
         early_reflections: int = 5,
-        sample_rate: Optional[int] = None,
+        sample_rate: int | None = None,
     ) -> np.ndarray:
         """
         Apply reverb effect to audio.
@@ -351,7 +347,7 @@ class AudioProcessor:
         self,
         audio: np.ndarray,
         bits: int = 8,
-        sample_rate: Optional[int] = None,
+        sample_rate: int | None = None,
     ) -> np.ndarray:
         """
         Apply bitcrush effect (lo-fi).
@@ -429,7 +425,7 @@ class AudioProcessor:
         self,
         audio: np.ndarray,
         output_path: str | Path,
-        sample_rate: Optional[int] = None,
+        sample_rate: int | None = None,
         format: str = "wav",
     ) -> None:
         """
@@ -447,7 +443,7 @@ class AudioProcessor:
 def process_audio(
     audio: np.ndarray,
     sample_rate: int = 24000,
-    effects: Optional[list[dict[str, any]]] = None,
+    effects: list[dict[str, any]] | None = None,
 ) -> np.ndarray:
     """
     Convenience function to process audio with effects.

--- a/src/champi_tts/core/audio_effects.py
+++ b/src/champi_tts/core/audio_effects.py
@@ -174,9 +174,9 @@ class AudioProcessor:
         # Apply multiple echoes with decreasing amplitude
         result = audio.copy()
         for i in range(3):
-            decayed = decay ** i
+            decayed = decay**i
             spreaded = int(spread * delay_samples)
-            echo = result[:-delay_samples - spreaded]
+            echo = result[: -delay_samples - spreaded]
             result[-spreaded - delay_samples - 1 : -spreaded] += echo * decayed
 
         return result
@@ -286,7 +286,9 @@ class AudioProcessor:
         # Calculate RMS
         window_size = int(0.01 * self.sample_rate)  # 10ms window
 
-        rms = np.sqrt(np.convolve(audio**2, np.ones(window_size), mode="valid") / window_size)
+        rms = np.sqrt(
+            np.convolve(audio**2, np.ones(window_size), mode="valid") / window_size
+        )
         rms_db = 20 * np.log10(rms + 1e-10)
 
         # Calculate gain reduction
@@ -437,7 +439,9 @@ class AudioProcessor:
             sample_rate: Sample rate for saving
             format: Audio format
         """
-        await load_audio.__func__(audio, output_path, sample_rate or self.sample_rate, format)
+        await load_audio.__func__(
+            audio, output_path, sample_rate or self.sample_rate, format
+        )
 
 
 def process_audio(

--- a/src/champi_tts/core/config_validation.py
+++ b/src/champi_tts/core/config_validation.py
@@ -6,14 +6,14 @@ Provides validation functions for configuration objects.
 
 import os
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any
 
 from loguru import logger
 
 
 def validate_voice_name(
     voice: str,
-    available_voices: Optional[list[str]] = None,
+    available_voices: list[str] | None = None,
     voice_prefix: str = "af_",
 ) -> tuple[bool, str]:
     """
@@ -63,7 +63,7 @@ def validate_voice_name(
 
 
 def validate_speed(
-    speed: Optional[float],
+    speed: float | None,
     default_speed: float = 1.0,
     min_speed: float = 0.5,
     max_speed: float = 2.0,
@@ -166,7 +166,7 @@ def validate_cache_path(
 
 
 def validate_sample_rate(
-    sample_rate: Optional[int],
+    sample_rate: int | None,
     default_rate: int = 22050,
 ) -> tuple[int, str]:
     """
@@ -259,7 +259,7 @@ def validate_config(
 
     # Validate speed
     if "default_speed" in config:
-        validated, message = validate_speed(config["default_speed"])
+        _validated, message = validate_speed(config["default_speed"])
         logger.debug(message)
 
     # Validate model path
@@ -279,18 +279,18 @@ def validate_config(
 
     # Validate sample rate
     if "sample_rate" in config:
-        validated, message = validate_sample_rate(config["sample_rate"])
+        _validated, message = validate_sample_rate(config["sample_rate"])
         logger.debug(message)
 
     return errors
 
 
 def validate_all(
-    voice: Optional[str] = None,
-    speed: Optional[float] = None,
-    model_path: Optional[str] = None,
-    cache_path: Optional[str] = None,
-    sample_rate: Optional[int] = None,
+    voice: str | None = None,
+    speed: float | None = None,
+    model_path: str | None = None,
+    cache_path: str | None = None,
+    sample_rate: int | None = None,
 ) -> bool:
     """
     Validate all configuration parameters.
@@ -317,7 +317,7 @@ def validate_all(
 
     if errors:
         logger.error(
-            f"Configuration validation failed:\n"
+            "Configuration validation failed:\n"
             + "\n".join(f"  {field}: {message}" for field, message in errors)
         )
         return False
@@ -326,13 +326,13 @@ def validate_all(
 
 
 # Environment variable helpers
-def get_env_voice() -> Optional[str]:
+def get_env_voice() -> str | None:
     """Get voice from environment or None."""
     voice = os.getenv("CHAMPI_KOKORO_DEFAULT_VOICE")
     return voice
 
 
-def get_env_speed() -> Optional[float]:
+def get_env_speed() -> float | None:
     """Get speed from environment or None."""
     speed_str = os.getenv("CHAMPI_KOKORO_DEFAULT_SPEED")
     if speed_str:

--- a/src/champi_tts/core/config_validation.py
+++ b/src/champi_tts/core/config_validation.py
@@ -51,8 +51,10 @@ def validate_voice_name(
             # Common American voices
             pass
         else:
-            available_str = ", ".join(available_voices[:5]) + "..." if len(available_voices) > 5 else ", ".join(
-                available_voices
+            available_str = (
+                ", ".join(available_voices[:5]) + "..."
+                if len(available_voices) > 5
+                else ", ".join(available_voices)
             )
             return (
                 False,

--- a/src/champi_tts/factory.py
+++ b/src/champi_tts/factory.py
@@ -28,6 +28,7 @@ def _lazy_import(module_name: str) -> object:
         _lazy_modules[module_name] = __import__(module_name)
     return _lazy_modules[module_name]
 
+
 # Type for supported providers
 ProviderType = Literal["kokoro"]  # Will add more providers later
 
@@ -73,9 +74,9 @@ def get_provider(
                 # Use default config
                 kokoro_config = KokoroConfig()
         else:
-            assert isinstance(
-                config, KokoroConfig
-            ), "config must be KokoroConfig for kokoro provider"
+            assert isinstance(config, KokoroConfig), (
+                "config must be KokoroConfig for kokoro provider"
+            )
             kokoro_config = config
 
         return KokoroProviderAdapter(config=kokoro_config)
@@ -93,7 +94,7 @@ def get_provider(
 
     else:
         raise ValueError(
-            f"Unknown provider type: {provider_type}. " f"Supported providers: kokoro"
+            f"Unknown provider type: {provider_type}. Supported providers: kokoro"
         )
 
 

--- a/src/champi_tts/factory.py
+++ b/src/champi_tts/factory.py
@@ -4,7 +4,6 @@ Provider factory for creating TTS providers and readers.
 Uses lazy loading to reduce initial startup time.
 """
 
-import sys
 from typing import Literal
 
 from champi_tts.core.base_config import BaseTTSConfig

--- a/src/champi_tts/providers/kokoro/events.py
+++ b/src/champi_tts/providers/kokoro/events.py
@@ -1,4 +1,5 @@
 """Signals system for Kokoro TTS service using champi-signals."""
+
 from blinker import Signal
 from champi_signals import BaseSignalManager, TTSEventTypes
 

--- a/src/champi_tts/providers/kokoro/provider.py
+++ b/src/champi_tts/providers/kokoro/provider.py
@@ -1029,7 +1029,7 @@ class KokoroProvider:
                     end_page = min(doc.page_count, page_range[1])
 
                 logger.debug(
-                    f"Extracting text from PDF: {pdf_path} (pages {start_page+1}-{end_page})"
+                    f"Extracting text from PDF: {pdf_path} (pages {start_page + 1}-{end_page})"
                 )
 
                 for page_num in range(start_page, end_page):
@@ -1070,7 +1070,7 @@ class KokoroProvider:
                         end_page = min(len(reader.pages), page_range[1])
 
                     logger.debug(
-                        f"Extracting text from PDF with PyPDF2: {pdf_path} (pages {start_page+1}-{end_page})"
+                        f"Extracting text from PDF with PyPDF2: {pdf_path} (pages {start_page + 1}-{end_page})"
                     )
 
                     for page_num in range(start_page, end_page):
@@ -1683,7 +1683,7 @@ if __name__ == "__main__":
 
             # Test web page reading and synthesis
             print("\n🌐 Testing Web Page Reading & Synthesis")
-            print(f"{'='*60}")
+            print(f"{'=' * 60}")
 
             test_url = "https://blog.jetbrains.com/pycharm/2025/07/faster-python-unlocking-the-python-global-interpreter-lock/"
             print(f"📄 Testing URL: {test_url}")
@@ -1744,7 +1744,7 @@ if __name__ == "__main__":
                 print(f"   ❌ Web page test failed: {e}")
                 # Don't let web page test failure stop the entire test
 
-            print(f"\n{'-'*60}")
+            print(f"\n{'-' * 60}")
 
         except Exception as e:
             print(f"❌ Provider test failed: {e}")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,6 @@
 Pytest configuration and fixtures for champi-tts tests.
 """
 
-
 import numpy as np
 import pytest
 

--- a/tests/test_integration/conftest.py
+++ b/tests/test_integration/conftest.py
@@ -26,6 +26,7 @@ def initialized_provider(mock_provider):
 def temp_audio_file(tmp_path):
     """Create temporary audio file for testing."""
     import numpy as np
+
     from champi_tts.core.audio import save_audio
 
     # Create test audio

--- a/tests/test_integration/test_audio_integration.py
+++ b/tests/test_integration/test_audio_integration.py
@@ -83,10 +83,7 @@ async def test_save_audio_file(mock_audio_data):
 
     # Save audio
     await save_audio(
-        mock_audio_data,
-        temp_path,
-        sample_rate=22050,
-        format=SF_FORMAT_WAV
+        mock_audio_data, temp_path, sample_rate=22050, format=SF_FORMAT_WAV
     )
 
     # Verify file exists
@@ -195,4 +192,3 @@ async def test_audio_player_volume_reset(audio_player):
     audio_player.volume = 0.5
     audio_player.set_volume()  # Reset to default
     assert audio_player.volume == 1.0
-

--- a/tests/test_integration/test_audio_integration.py
+++ b/tests/test_integration/test_audio_integration.py
@@ -4,13 +4,14 @@ Integration tests for audio handling.
 These tests verify audio playback, file I/O, and synthesis functionality.
 """
 
-import numpy as np
-import pytest
 import tempfile
 from pathlib import Path
 
+import numpy as np
+import pytest
+from soundfile import SF_FORMAT_WAV
+
 from champi_tts.core.audio import AudioPlayer, load_audio, save_audio
-from soundfile import SF_FORMAT_WAV, SF_FORMAT_PCM_16
 
 
 @pytest.fixture

--- a/tests/test_integration/test_full_workflow.py
+++ b/tests/test_integration/test_full_workflow.py
@@ -322,6 +322,7 @@ async def test_read_text_with_voice():
     voices_used = []
 
     original_synthesize = provider.synthesize
+
     async def tracked_synthesize(*args, voice=None, **kwargs):
         voices_used.append(voice or config.default_voice)
         return await original_synthesize(*args, **kwargs)
@@ -352,6 +353,7 @@ async def test_read_text_with_speed():
     speeds_used = []
 
     original_synthesize = provider.synthesize
+
     async def tracked_synthesize(*args, speed=None, **kwargs):
         speeds_used.append(speed or config.default_speed)
         return await original_synthesize(*args, **kwargs)
@@ -366,4 +368,3 @@ async def test_read_text_with_speed():
     speeds_used.clear()
     await reader.read_text("Test")
     assert speeds_used[-1] == 1.0
-

--- a/tests/test_integration/test_full_workflow.py
+++ b/tests/test_integration/test_full_workflow.py
@@ -10,12 +10,11 @@ These tests verify end-to-end functionality including:
 """
 
 import asyncio
-import pytest
 from pathlib import Path
 
+import pytest
+
 from champi_tts import ReaderState, TextReaderService
-from champi_tts.core.audio import AudioPlayer
-from champi_tts.factory import get_provider
 
 
 @pytest.fixture
@@ -66,7 +65,7 @@ async def test_pause_resume_sequence(mock_provider):
 
     # Start another read that can be paused
     async def long_read():
-        for i in range(10):
+        for _i in range(10):
             if reader.state == ReaderState.PAUSED:
                 break
             await asyncio.sleep(0.01)
@@ -122,7 +121,7 @@ async def test_queue_management():
     """
     Test queue management with edge cases.
     """
-    from tests.conftest import MockTTSProvider, MockTTSConfig
+    from tests.conftest import MockTTSConfig, MockTTSProvider
 
     config = MockTTSConfig()
     provider = MockTTSProvider(config)
@@ -148,7 +147,7 @@ async def test_queue_with_pause_resume():
     """
     Test queue operations with pause/resume.
     """
-    from tests.conftest import MockTTSProvider, MockTTSConfig
+    from tests.conftest import MockTTSConfig, MockTTSProvider
 
     config = MockTTSConfig()
     provider = MockTTSProvider(config)
@@ -178,7 +177,7 @@ async def test_read_file_workflow():
     """
     Test reading from file with paragraph processing.
     """
-    from tests.conftest import MockTTSProvider, MockTTSConfig
+    from tests.conftest import MockTTSConfig, MockTTSProvider
 
     config = MockTTSConfig()
     provider = MockTTSProvider(config)
@@ -213,7 +212,7 @@ async def test_file_not_found():
     """
     Test reading from non-existent file raises FileNotFoundError.
     """
-    from tests.conftest import MockTTSProvider, MockTTSConfig
+    from tests.conftest import MockTTSConfig, MockTTSProvider
 
     config = MockTTSConfig()
     provider = MockTTSProvider(config)
@@ -228,7 +227,7 @@ async def test_error_handling():
     """
     Test error handling during synthesis.
     """
-    from tests.conftest import MockTTSProvider, MockTTSConfig
+    from tests.conftest import MockTTSConfig, MockTTSProvider
 
     config = MockTTSConfig()
     provider = MockTTSProvider(config)
@@ -250,7 +249,7 @@ async def test_state_transitions():
     """
     Test all state transition paths.
     """
-    from tests.conftest import MockTTSProvider, MockTTSConfig
+    from tests.conftest import MockTTSConfig, MockTTSProvider
 
     config = MockTTSConfig()
     provider = MockTTSProvider(config)
@@ -273,7 +272,7 @@ async def test_reader_cleanup():
     """
     Test reader cleanup on exit.
     """
-    from tests.conftest import MockTTSProvider, MockTTSConfig
+    from tests.conftest import MockTTSConfig, MockTTSProvider
 
     config = MockTTSConfig()
     provider = MockTTSProvider(config)
@@ -313,7 +312,7 @@ async def test_read_text_with_voice():
     """
     Test reading text with custom voice parameter.
     """
-    from tests.conftest import MockTTSProvider, MockTTSConfig
+    from tests.conftest import MockTTSConfig, MockTTSProvider
 
     config = MockTTSConfig(default_voice="af_bella")
     provider = MockTTSProvider(config)
@@ -344,7 +343,7 @@ async def test_read_text_with_speed():
     """
     Test reading text with custom speed parameter.
     """
-    from tests.conftest import MockTTSProvider, MockTTSConfig
+    from tests.conftest import MockTTSConfig, MockTTSProvider
 
     config = MockTTSConfig(default_speed=1.0)
     provider = MockTTSProvider(config)

--- a/tests/test_integration/test_ui_integration.py
+++ b/tests/test_integration/test_ui_integration.py
@@ -4,9 +4,12 @@ Integration tests for UI indicator.
 These tests verify UI state transitions and visual indicator functionality.
 """
 
+import contextlib
+
 import pytest
 
 from champi_tts import TTSIndicatorUI, TTSState
+from champi_tts.reader import ReaderState
 
 
 @pytest.fixture
@@ -129,10 +132,8 @@ async def test_reader_events_update_ui(mock_provider):
     reader.on_state_changed.connect(track_ui_state)
 
     # Read some text
-    try:
+    with contextlib.suppress(Exception):
         await reader.read_text("Test text")
-    except Exception:
-        pass  # Expected to fail without actual provider
 
     # UI should have been updated
     # Note: The exact sequence depends on signal timing

--- a/tests/test_integration/test_ui_integration.py
+++ b/tests/test_integration/test_ui_integration.py
@@ -31,7 +31,13 @@ def test_ui_update_state(ui):
 
 def test_ui_state_cycle(ui):
     """Test cycling through all UI states."""
-    states = [TTSState.IDLE, TTSState.PROCESSING, TTSState.SPEAKING, TTSState.PAUSED, TTSState.ERROR]
+    states = [
+        TTSState.IDLE,
+        TTSState.PROCESSING,
+        TTSState.SPEAKING,
+        TTSState.PAUSED,
+        TTSState.ERROR,
+    ]
 
     for state in states:
         ui.update_state(state)
@@ -154,4 +160,3 @@ async def test_reader_error_updates_ui(mock_provider):
     # Simulate error state
     reader._set_state(ReaderState.IDLE)  # This will emit state_changed signal
     # UI should have received the state change
-

--- a/tests/test_performance.py
+++ b/tests/test_performance.py
@@ -7,8 +7,6 @@ to detect regressions and track improvements.
 
 import asyncio
 import time
-import timeit
-from pathlib import Path
 
 import numpy as np
 import pytest
@@ -43,7 +41,7 @@ async def test_synthesize_performance():
     synthesis_times = []
     for _ in range(3):
         start = time.perf_counter()
-        audio = await provider.synthesize(text)
+        await provider.synthesize(text)
         synthesis_times.append(time.perf_counter() - start)
         await provider.shutdown()
 
@@ -54,7 +52,7 @@ async def test_synthesize_performance():
     synthesis_times = []
     for _ in range(3):
         start = time.perf_counter()
-        audio = await provider.synthesize(text)
+        await provider.synthesize(text)
         synthesis_times.append(time.perf_counter() - start)
         await provider.shutdown()
 
@@ -132,7 +130,7 @@ def test_config_validation_performance():
     validation_times = []
     for _ in range(100):
         start = time.perf_counter()
-        errors = validate_config(config)
+        validate_config(config)
         validation_times.append(time.perf_counter() - start)
 
     avg_validation_time = np.mean(validation_times)
@@ -147,13 +145,13 @@ def test_lazy_import_performance():
 
     # First import (should take longer)
     start = time.perf_counter()
-    module = _lazy_import("numpy")
+    _lazy_import("numpy")
     first_import_time = time.perf_counter() - start
 
     # Subsequent imports (should be fast)
     for _ in range(10):
         start = time.perf_counter()
-        module = _lazy_import("numpy")
+        _lazy_import("numpy")
         import_time.append(time.perf_counter() - start)
 
     assert first_import_time < 5.0, f"First lazy import took too long: {first_import_time}s"
@@ -165,7 +163,6 @@ def test_memory_usage():
     import gc
 
     from champi_tts.factory import get_provider
-    from tests.conftest import MockTTSConfig, MockTTSProvider
 
     # Get initial memory
     gc.collect()
@@ -179,7 +176,7 @@ def test_memory_usage():
     # Cleanup
     provider.shutdown()
     gc.collect()
-    final_memory = sum(obj for obj in gc.get_objects() if isinstance(obj, np.ndarray))
+    sum(obj for obj in gc.get_objects() if isinstance(obj, np.ndarray))
 
     # Memory should not increase significantly
     delta = provider_memory - initial_memory
@@ -198,7 +195,7 @@ async def test_long_document_performance():
 
     # Create long text (like a book chapter)
     paragraphs = ["This is paragraph " + str(i) + ". " * 10 for i in range(100)]
-    long_text = "\n\n".join(paragraphs)
+    "\n\n".join(paragraphs)
 
     read_times = []
 

--- a/tests/test_performance.py
+++ b/tests/test_performance.py
@@ -46,7 +46,9 @@ async def test_synthesize_performance():
         await provider.shutdown()
 
     avg_first_synthesis = np.mean(synthesis_times)
-    assert avg_first_synthesis < 30.0, f"First synthesis took too long: {avg_first_synthesis}s"
+    assert avg_first_synthesis < 30.0, (
+        f"First synthesis took too long: {avg_first_synthesis}s"
+    )
 
     # Measure subsequent synthesis times (no loading overhead)
     synthesis_times = []
@@ -58,7 +60,9 @@ async def test_synthesize_performance():
 
     avg_subsequent_synthesis = np.mean(synthesis_times)
     # Allow some variance but should be reasonable
-    assert avg_subsequent_synthesis < 10.0, f"Subsequent synthesis took too long: {avg_subsequent_synthesis}s"
+    assert avg_subsequent_synthesis < 10.0, (
+        f"Subsequent synthesis took too long: {avg_subsequent_synthesis}s"
+    )
 
 
 @pytest.mark.asyncio
@@ -91,7 +95,9 @@ async def test_reader_performance():
             await reader.read_text(f"Queue text {i}")
         queue_times.append(time.perf_counter() - start)
 
-    assert np.mean(queue_times) < 30.0, f"Queue processing took too long: {np.mean(queue_times)}s"
+    assert np.mean(queue_times) < 30.0, (
+        f"Queue processing took too long: {np.mean(queue_times)}s"
+    )
 
 
 @pytest.mark.asyncio
@@ -111,7 +117,9 @@ async def test_audio_player_performance():
         player.stop()
         play_times.append(time.perf_counter() - start)
 
-    assert np.mean(play_times) < 0.1, f"Audio playback was too slow: {np.mean(play_times)}s"
+    assert np.mean(play_times) < 0.1, (
+        f"Audio playback was too slow: {np.mean(play_times)}s"
+    )
 
 
 def test_config_validation_performance():
@@ -134,7 +142,9 @@ def test_config_validation_performance():
         validation_times.append(time.perf_counter() - start)
 
     avg_validation_time = np.mean(validation_times)
-    assert avg_validation_time < 0.01, f"Validation took too long: {avg_validation_time}s"
+    assert avg_validation_time < 0.01, (
+        f"Validation took too long: {avg_validation_time}s"
+    )
 
 
 def test_lazy_import_performance():
@@ -154,8 +164,12 @@ def test_lazy_import_performance():
         _lazy_import("numpy")
         import_time.append(time.perf_counter() - start)
 
-    assert first_import_time < 5.0, f"First lazy import took too long: {first_import_time}s"
-    assert np.mean(import_time) < 0.001, f"Subsequent imports were slow: {np.mean(import_time)}s"
+    assert first_import_time < 5.0, (
+        f"First lazy import took too long: {first_import_time}s"
+    )
+    assert np.mean(import_time) < 0.001, (
+        f"Subsequent imports were slow: {np.mean(import_time)}s"
+    )
 
 
 def test_memory_usage():
@@ -171,7 +185,9 @@ def test_memory_usage():
     # Create provider
     provider = get_provider()
     gc.collect()
-    provider_memory = sum(obj for obj in gc.get_objects() if isinstance(obj, np.ndarray))
+    provider_memory = sum(
+        obj for obj in gc.get_objects() if isinstance(obj, np.ndarray)
+    )
 
     # Cleanup
     provider.shutdown()

--- a/tests/test_reader/test_service.py
+++ b/tests/test_reader/test_service.py
@@ -2,7 +2,6 @@
 Tests for the text reader service.
 """
 
-
 import contextlib
 
 import pytest


### PR DESCRIPTION
## Summary
- Auto-fix 54 ruff issues (unused imports, string concatenation, f-string fixes, etc.)
- Fix unused unpacked variable `validated` in `config_validation.py`
- Fix undefined `ReaderState` import in `test_ui_integration.py`
- Replace `try-except-pass` with `contextlib.suppress()` in tests
- Lower `genbadge[coverage]` bound to `>=1.1.0` (latest is 1.1.3, `>=1.6.0` is unsatisfiable)

## Test plan
- [ ] `ruff check src/ tests/` reports no errors
- [ ] CI passes on Python 3.12 and 3.13