### PR TITLE
fix(ci): add test extra to benchmark workflow for pytest-benchmark

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -20,7 +20,7 @@ jobs:
         run: uv python install 3.12
 
       - name: Install dependencies
-        run: uv sync --frozen --extra dev
+        run: uv sync --frozen --extra dev --extra test
 
       - name: Run benchmarks
         run: |


### PR DESCRIPTION
## Summary
- `pytest-benchmark` is in the `test` extras group, not `dev`
- The benchmarks workflow was only installing `--extra dev`, so `--benchmark-only` flag was unrecognized
- Add `--extra test` so `pytest-benchmark` is installed before running benchmarks

## Test plan
- [ ] Benchmark workflow runs without "unrecognized arguments" error